### PR TITLE
New Require.js docs

### DIFF
--- a/src/content/0.8/plus/02-RequireJS.md
+++ b/src/content/0.8/plus/02-RequireJS.md
@@ -1,173 +1,190 @@
-This page shows how to configure a project that uses [RequireJS]. It is based on Jake's [post].
+To get Karma to run with [Require.js] we need two files:
+
+* `karma.conf.js` &mdash; which configures Karma
+* `test-main.js` &mdash; which configures Require.js for the tests
+
+Let's say our app has a directory structure which looks something like
+this:
+
+```bash
+$ tree
+.
+|-- index.html
+|-- karma.conf.js
+|-- lib
+|   |-- jquery.js
+|   |-- require.js
+|   `-- underscore.js
+|-- src
+|   |-- app.js
+|   `-- main.js
+`-- test
+    |-- appSpec.js
+    `-- test-main.js
+
+3 directories, 9 files
+```
 
 ## Configure Karma
 
-### Directory Setup
+The first step is creating our `karma.conf.js`. We can do this from the
+command line:
 
-For clarity in the example configuration files and test below, the
-directory structure upon which these are based looks like this:
-```bash
-project/
-  lib/
-    jquery.js #etc
-  node_modules/
-    chai/ #etc
-  src/
-    MyModule.js
-  test/
-    MyModule.test.js
-    test-main.js
-testacular.conf.js
-```
-
-### Initialize Karma
-
-Karma comes with a nice utility for generating a config file
-(default name: `testacular.conf.js`) that it needs in order to run.
-
-In your terminal, type:
 ```bash
 $ karma init
 ```
+
 This will give you a series of prompts for things such as paths to
-source and tests and which browsers to capture.
+source and test and which browsers to capture.
 
-### RequireJs Shim
-Not immediately apparent is the fact that the ‘shim’ config from
-RequireJs 2.x does not work from within Karma. I haven’t yet
-figured out why. For instance, I was constantly getting `‘Backbone’ is
-not defined` messages even though it was specified in the ‘shim’
-config and required in the test. I could have been doing something
-wrong. My solution thus far has been to list each of the non-RequireJs
-modules and their dependencies in the `files` attribute of
-`testacular.conf.js`.
+In this example we'll use Jasmine, but other test frameworks works just
+as well.
 
-### `testacular.conf.js`
-The final point is that the RequireJs main module for your test runner
-should be the last file listed.
+Choose "yes" for Require.js.
 
-So, finally, here is the ‘file’ excerpt of `testacular.conf.js`:
+For the question *"Which files do you want to include with &lt;script&gt;
+tag?"*, we need to choose all files which are *not* loaded by Require.js.
+Usually you'll only need to include your `test-main.js` file, which has
+the same role for your tests as `main.js` has for your app when using
+Require.js.
+
+For the qustion *"Which files do you want to test?"*, we choose all the
+files we want to load with Require.js. For this example we'll need:
+
+* `lib/**/*.js` &mdash; all external libraries
+* `src/**/*.js` &mdash; our source code
+* `test/**/*Spec.js` &mdash; all the tests
+
+And then, for excludes, type `src/main.js`, as we don't want to actually
+start the application in our tests.
+
+Now your `karma.conf.js` should include:
+
 ```javascript
+// list of files / patterns to load in the browser
 files = [
-  MOCHA,
-  MOCHA_ADAPTER,
+  JASMINE,
+  JASMINE_ADAPTER,
   REQUIRE,
   REQUIRE_ADAPTER,
 
-  // libs required for test framework
-  {pattern: 'node_modules/chai/chai.js', included: false},
-
-  // put what used to be in your requirejs 'shim' config here,
-  // these files will be included without requirejs
-  'lib/jquery.js',
-  'lib/underscore.js',
-  'lib/backbone.js',
-  'lib/handlebars.js',
-
-  // put all libs in requirejs 'paths' config here (included: false)
   {pattern: 'lib/**/*.js', included: false},
+  {pattern: 'src/**/*.js', included: false},
+  {pattern: 'test/**/*Spec.js', included: false},
 
-  // all src and test modules (included: false)
-  {pattern: 'src/**/*', included: false},
-  {pattern: 'test/**/*.test.js', included: false},
-
-  // test main require module last
   'test/test-main.js'
 ];
-```
-This config is awesome. It replaces an html test runner that you would otherwise have to build.
 
-## RequireJs Main Module
-Just like any RequireJs project, you need a main module to bootstrap
-your tests. In the main module, you setup the `require.config`.
+// list of files to exclude
+exclude = [
+    'src/main.js'
+];
+```
+
+## Configuring Require.js
+
+Just like any Require.js project, you need a main module to bootstrap
+your tests. We do this is `test/test-main.js`.
 
 ### Karma `/base` Directory
-Karma serves files under the `/base` directory. So, on the
-server, requests to files will be served up under
-`http://localhost:9876/base/*`. The RequireJs config for `baseUrl`
-gives a starting context for modules that load with relative paths.
-When setting this value for the Karma server, it will need to
-start with `/base`. I want my baseUrl to be at the root of my `/src`
-directory so relative requires in the source won’t need to change. My
-baseUrl has the value of `/base/src`.
+
+Karma serves files under the `/base` directory. So, on the server
+requests to files will be served up under
+`http://localhost:9876/base/*`.
+
+The Require.js config for `baseUrl` gives a starting context for modules
+that load with relative paths. When setting this value for the Karma
+server it will need to start with `/base`. We want the `baseUrl` for our
+tests to be the same folder as the base url we have in `src/main.js`, so
+that relative requires in the source won’t need to change. So, as we
+want our base url to be at `src/`, we need to write `/base/src`.
 
 ### Require Each Test File
-One of the things I hate is having to update a master list of all
-tests to run every time I add a test. There is no config option for
-this, but there's an easy way to get around it by filtering the tests
-from the `window.__testacular__.files` object.
-The code is included in the example below and the original suggestion
-came from <https://github.com/karma-runner/karma/pull/236>.
 
-### Asynchronously Run Karma
-Because the RequireJs require statements are asynchronous, Karma
-needs to wait until they’re done (the code is loaded and ready) before
-it starts the tests.
+With Karma we don't need to list all test files ourselves as we can
+easily find them from the files specified in `test-main.js`: Karma
+includes all the files in `window.__karma__.files`, so by filtering this
+array we find all our test files.
 
-The main-test.js file ends up looking like this:
+Now we can tell Require.js to load our tests, which must be done
+asynchronously as dependencies must be fetched before the tests are run.
+The `test/main-test.js` file ends up looking like this:
+
 ```javascript
-var tests = Object.keys(window.__testacular__.files).filter(function (file) {
-  return /\.test\.js$/.test(file);
+var tests = Object.keys(window.__karma__.files).filter(function (file) {
+      return /Spec\.js$/.test(file);
 });
 
-require({
-  // Karma serves files from '/base'
-  baseUrl: '/base/src',
-  paths: {
-    require: '../lib/require',
-    text: '../lib/text'
-  },
-  // ask requirejs to load these files (all our tests)
-  deps: tests,
-  // start test run, once requirejs is done
-  callback: window.__testacular__.start
+requirejs.config({
+    // Karma serves files from '/base'
+    baseUrl: '/base/src',
+
+    paths: {
+        'jquery': '../lib/jquery',
+        'underscore': '../lib/underscore',
+    },
+
+    shim: {
+        'underscore': {
+            exports: '_'
+        }
+    },
+
+    // ask Require.js to load these files (all our tests)
+    deps: tests,
+
+    // start test run, once Require.js is done
+    callback: window.__karma__.start
 });
 ```
 
-## RequireJs Test in Karma
-All the setup thus far has been in preparation for the code to follow.
-The test can now be setup as a RequireJs module. It can require the
-source code under test. It can use Mocha (or whatever framework there
-is a Karma adapter for).
+## Using Require.js in tests
 
-I will also use Chai in order to get the ‘should’ BDD-style
-assertions. Note that by using RequireJs and running in the browser,
-we can’t just `require('chai')`. It has to be required using the
-asynchronous callback to avoid this error:
-```bash
-Uncaught Error: Module name “../node_modules/chai/chai” has not been loaded yet for context: _. Use require([])
-```
-And finally, `should()` must be invoked to be available in the test.
+Tests can now be written as regular Require.js modules. We wrap
+everything in `define`, and inside we can use the regular test methods,
+such as `describe` and `it`. Example:
 
-So, a simple test will look like:
 ```javascript
-define(['../node_modules/chai/chai', 'MyModule'], function(chai, MyModule) {
+define(['app', 'jquery', 'underscore'], function(App, $, _) {
 
-  var should = chai.should();
+    describe('just checking', function() {
 
-  describe('MyModule', function () {
-    describe('#initialize()', function () {
-      it('should be a stinkin object', function () {
-        var yippee = new MyModule();
-        yippee.should.be.an('object');
-      });
+        it('works for app', function() {
+            var el = $('<div></div>');
+
+            var app = new App(el);
+            app.render();
+
+            expect(el.text()).toEqual('require.js up and running');
+        });
+
+        it('works for underscore', function() {
+            // just checking that _ works
+            expect(_.size([1,2,3])).toEqual(3);
+        });
+
     });
-  });
+
 });
 ```
 
-## Run the Tests in Karma
-To start the Karma server:
+## Running the tests
+
+We can now run the tests from the command line:
+
 ```bash
 $ karma start
 ```
 
-If you didn't configure to watch all the files and run tests automatically on any change, you can trigger the tests manually. Just type:
+If you didn't configure Karma to watch all the files and run tests
+automatically on any change, you can trigger the tests manually by
+typing:
+
 ```bash
 $ karma run
 ```
 
+[Here is a running example of Karma with Require.js][example].
 
-
-[RequireJS]: http://requirejs.org/
-[post]: http://jaketrent.com/post/test-requirejs-testacular/
+[Require.js]: http://requirejs.org/
+[example]: https://github.com/kjbekkelund/karma-requirejs


### PR DESCRIPTION
I've done quite a bit of changes to the Require.js docs. I have created a running example at https://github.com/kjbekkelund/karma-requirejs which I have used as the basis for the description (I've also linked to it from the docs, so people can easily find a running setup — let me know if I should remove the link).

In the old docs Require.js `shims` weren't handled properly. Also, in this setup all includes are based on globs so you don't have to keep the config up to date when adding new files.

Let me know if the text needs more work. English is not my mother tongue so there might be some oddities, but hopefully it should be quite simple and understandable.
