### PR TITLE
Add banner for old versions

### DIFF
--- a/src/jade/layout.jade
+++ b/src/jade/layout.jade
@@ -7,6 +7,10 @@ include html
   body
     #wrap.boxed
       header
+        if oldVersion
+          .flash
+              | <b>Heads Up!</b> You're viewing the docs for <b>v#{self.version}</b>, an old version of Karma.
+              | <a href="/#{self.newUrl}"><b>v#{versions[0]}</b> is the newest</a>.
         .container.clearfix
           .six.columns
             .logo

--- a/src/less/custom.less
+++ b/src/less/custom.less
@@ -11,6 +11,23 @@
 	}
 }
 
+.flash {
+	text-align: center;
+	background-color: #585858;
+	color: #fff;
+	font-size: @fontSizeLarge;
+	padding: @paddingLarge;
+	border-bottom: 5px solid @darkHrBorderColor;
+
+	b {
+		font-weight: bold;
+	}
+
+	a {
+		color: #00aec8;
+	}
+}
+
 .logo {
   margin: 12px 0 12px 0;
 }

--- a/tasks/static.js
+++ b/tasks/static.js
@@ -118,8 +118,10 @@ module.exports = function(grunt) {
           return q.all([getJadeTpl(file.layout), fs.makeTree(path.dirname(fileUrl))]).then(function(args) {
             var jadeTpl = args[0];
 
+            file.newUrl = file.url.replace(file.version, versions[0]);
             return fs.write(fileUrl, jadeTpl({
               versions: versions,
+              oldVersion: file.version !== versions[0],
               menu: menu[file.version],
               self: file
             }));


### PR DESCRIPTION
Sometimes you'll come across a link on Google or StackOverflow that points to an old version of the docs. It's not obvious from the current site design when you're on an old version of the docs.

This adds a banner to all pages other than the highest semver'd folder of docs.

![screen shot 2014-06-06 at 4 29 05 pm](https://cloud.githubusercontent.com/assets/474988/3207003/7e515814-edd2-11e3-8ea2-606405c29d2b.png)

Closes #20
