### PR TITLE
Updated link to Mocha

### DIFF
--- a/src/jade/homepage.jade
+++ b/src/jade/homepage.jade
@@ -78,7 +78,7 @@ block content
           p
             :markdown
               Describe your tests with [Jasmine](http://jasmine.github.io/),
-              [Mocha](http://visionmedia.github.com/mocha/),
+              [Mocha](http://mochajs.org/),
               [QUnit](http://qunitjs.com/), or write a simple adapter for any framework you like.
 
         li.one-third.column.last


### PR DESCRIPTION
The current mocha link pointed to a 404. Seems like the homepage has moved.
