### PR TITLE
Add `link rel=canonical` for search engines

### DIFF
--- a/src/jade/head.jade
+++ b/src/jade/head.jade
@@ -21,3 +21,6 @@ link(rel='apple-touch-icon', href='/assets/img/apple-touch-icon.png')
 link(rel='apple-touch-icon', sizes='72x72', href='/assets/img/apple-touch-icon-72x72.png')
 link(rel='apple-touch-icon', sizes='114x114', href='/assets/img/apple-touch-icon-114x114.png')
 link(rel='apple-touch-icon-precomposed', sizes='144x144', href='/assets/img/apple-touch-icon-144x144.png')
+
+// canonical link for search engines
+link(href='http://karma-runner.github.io/' + canonicalUrl, rel='canonical')

--- a/tasks/static.js
+++ b/tasks/static.js
@@ -117,6 +117,7 @@ module.exports = function (grunt) {
             return fs.write(fileUrl, jadeTpl({
               versions: versions,
               oldVersion: file.version !== versions[0],
+              canonicalUrl: file.newUrl,
               editButton: file.editButton && file.version === versions[0],
               menu: menu[file.version],
               self: file


### PR DESCRIPTION
When searching in Google for karma-related docs, you get random
links sometimes pointing to v0.10, sometimes v0.12 etc.

This is because Google doesn't know the relationship between
the different files and tries to figure out the duplicated
content on its own.

When we provide canonical link, the search engine results
(after some time once reindexing is finished)
will be pointing almost always to the canonical (newest) link
in case of duplicate content found.

https://en.wikipedia.org/wiki/Canonical_link_element

---------

In case you're interested, I did the same kind of trick some time ago for another project I was working on (since we had exact same time) and after a few weeks, all Google search links started pointing always to the fresh version of docs (it was a bit different then though, since we put `latest` as a fixed canonical link, instead of changing it with every release, but it should not make much difference I hope)