### PR TITLE
Fix the newUrl variable on the template context

### DIFF
--- a/tasks/static.js
+++ b/tasks/static.js
@@ -115,8 +115,10 @@ module.exports = function (grunt) {
           return q.all([getJadeTpl(file.layout), fs.makeTree(path.dirname(fileUrl))]).then(function (args) {
             var jadeTpl = args[0]
 
-            file.newUrl = file.url.replace(file.version, versions[0])
-            file.newUrl = file.url.replace('coverage.html', 'preprocessors.html')
+            file.newUrl = file.url
+              .replace(file.version, versions[0])
+              .replace('coverage.html', 'preprocessors.html')
+
             return fs.write(fileUrl, jadeTpl({
               versions: versions,
               oldVersion: file.version !== versions[0],


### PR DESCRIPTION
I've noticed that the "flash" message announcing a more recent version of the project had an invalid URL (it pointed to the exact same URL on which I was currently seeing the warning).

This PR should fix this problem.