### PR TITLE
chore: convert landing page from using :marked to native Jade syntax

### DIFF
--- a/0.10/index.html
+++ b/0.10/index.html
@@ -143,12 +143,12 @@
         <p class="bold large center">Things should be simple. We believe in testing and so we want to make it as simple as possible.</p>
       </div>
       <div class="sixteen columns bottom">
-        <p class="center"><p>The main goal for Karma is to bring a productive testing
-environment to developers. The environment being one where they don&#39;t have
-to set up loads of configurations, but rather a place where developers can just write the
-code and get instant feedback from their tests. Because getting quick feedback is what makes you
-productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
-
+        <p>
+          The main goal for Karma is to bring a productive testing
+          environment to developers. The environment being one where they don&#39;t have
+          to set up loads of configurations, but rather a place where developers can just write the
+          code and get instant feedback from their tests. Because getting quick feedback is what makes you
+          productive and <a href="http://vimeo.com/36579366">creative</a>.
         </p>
       </div>
       <div class="clearfix"></div>
@@ -173,17 +173,17 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column">
             <div class="icon-box"><i class="icon-globe icon-2x"></i></div>
             <h3>Testing Framework Agnostic</h3>
-            <p><p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
-<a href="http://mochajs.org/">Mocha</a>,
-<a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.</p>
-
+            <p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
+              <a href="http://mochajs.org/">Mocha</a>,
+              <a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.
             </p>
           </li>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-group icon-2x"></i></div>
             <h3>Open Source</h3>
-            <p><p>Developed for and maintained by the open source community at <a href="https://github.com/karma-runner/karma">GitHub</a>.</p>
-
+            <p>
+              Developed for and maintained by the open source community at
+              <a href="https://github.com/karma-runner/karma">GitHub</a>.
             </p>
           </li>
           <li class="one-third column last">
@@ -194,10 +194,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-refresh icon-2x"></i></div>
             <h3>Continuous Integration</h3>
-            <p><p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
-<a href="plus/travis.html">Travis</a> or
-<a href="plus/semaphore.html">Semaphore</a>.</p>
-
+            <p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
+              <a href="plus/travis.html">Travis</a> or
+              <a href="plus/semaphore.html">Semaphore</a>.
             </p>
           </li>
         </ul>
@@ -221,9 +220,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
         <hr>
       </div>
       <div class="sixteen columns">
-        <p class="center"><p>For more motivation on why to use Karma and why we did it, check out
-the blog post on <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.</p>
-
+        <p>
+          For more motivation on why to use Karma and why we did it, check out the blog post on
+          <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.
         </p>
       </div>
     </div>

--- a/0.12/index.html
+++ b/0.12/index.html
@@ -148,12 +148,12 @@
         <p class="bold large center">Things should be simple. We believe in testing and so we want to make it as simple as possible.</p>
       </div>
       <div class="sixteen columns bottom">
-        <p class="center"><p>The main goal for Karma is to bring a productive testing
-environment to developers. The environment being one where they don&#39;t have
-to set up loads of configurations, but rather a place where developers can just write the
-code and get instant feedback from their tests. Because getting quick feedback is what makes you
-productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
-
+        <p>
+          The main goal for Karma is to bring a productive testing
+          environment to developers. The environment being one where they don&#39;t have
+          to set up loads of configurations, but rather a place where developers can just write the
+          code and get instant feedback from their tests. Because getting quick feedback is what makes you
+          productive and <a href="http://vimeo.com/36579366">creative</a>.
         </p>
       </div>
       <div class="clearfix"></div>
@@ -178,17 +178,17 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column">
             <div class="icon-box"><i class="icon-globe icon-2x"></i></div>
             <h3>Testing Framework Agnostic</h3>
-            <p><p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
-<a href="http://mochajs.org/">Mocha</a>,
-<a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.</p>
-
+            <p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
+              <a href="http://mochajs.org/">Mocha</a>,
+              <a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.
             </p>
           </li>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-group icon-2x"></i></div>
             <h3>Open Source</h3>
-            <p><p>Developed for and maintained by the open source community at <a href="https://github.com/karma-runner/karma">GitHub</a>.</p>
-
+            <p>
+              Developed for and maintained by the open source community at
+              <a href="https://github.com/karma-runner/karma">GitHub</a>.
             </p>
           </li>
           <li class="one-third column last">
@@ -199,10 +199,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-refresh icon-2x"></i></div>
             <h3>Continuous Integration</h3>
-            <p><p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
-<a href="plus/travis.html">Travis</a> or
-<a href="plus/semaphore.html">Semaphore</a>.</p>
-
+            <p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
+              <a href="plus/travis.html">Travis</a> or
+              <a href="plus/semaphore.html">Semaphore</a>.
             </p>
           </li>
         </ul>
@@ -226,9 +225,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
         <hr>
       </div>
       <div class="sixteen columns">
-        <p class="center"><p>For more motivation on why to use Karma and why we did it, check out
-the blog post on <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.</p>
-
+        <p>
+          For more motivation on why to use Karma and why we did it, check out the blog post on
+          <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.
         </p>
       </div>
     </div>

--- a/0.13/index.html
+++ b/0.13/index.html
@@ -148,12 +148,12 @@
         <p class="bold large center">Things should be simple. We believe in testing and so we want to make it as simple as possible.</p>
       </div>
       <div class="sixteen columns bottom">
-        <p class="center"><p>The main goal for Karma is to bring a productive testing
-environment to developers. The environment being one where they don&#39;t have
-to set up loads of configurations, but rather a place where developers can just write the
-code and get instant feedback from their tests. Because getting quick feedback is what makes you
-productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
-
+        <p>
+          The main goal for Karma is to bring a productive testing
+          environment to developers. The environment being one where they don&#39;t have
+          to set up loads of configurations, but rather a place where developers can just write the
+          code and get instant feedback from their tests. Because getting quick feedback is what makes you
+          productive and <a href="http://vimeo.com/36579366">creative</a>.
         </p>
       </div>
       <div class="clearfix"></div>
@@ -178,17 +178,17 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column">
             <div class="icon-box"><i class="icon-globe icon-2x"></i></div>
             <h3>Testing Framework Agnostic</h3>
-            <p><p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
-<a href="http://mochajs.org/">Mocha</a>,
-<a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.</p>
-
+            <p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
+              <a href="http://mochajs.org/">Mocha</a>,
+              <a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.
             </p>
           </li>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-group icon-2x"></i></div>
             <h3>Open Source</h3>
-            <p><p>Developed for and maintained by the open source community at <a href="https://github.com/karma-runner/karma">GitHub</a>.</p>
-
+            <p>
+              Developed for and maintained by the open source community at
+              <a href="https://github.com/karma-runner/karma">GitHub</a>.
             </p>
           </li>
           <li class="one-third column last">
@@ -199,10 +199,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-refresh icon-2x"></i></div>
             <h3>Continuous Integration</h3>
-            <p><p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
-<a href="plus/travis.html">Travis</a> or
-<a href="plus/semaphore.html">Semaphore</a>.</p>
-
+            <p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
+              <a href="plus/travis.html">Travis</a> or
+              <a href="plus/semaphore.html">Semaphore</a>.
             </p>
           </li>
         </ul>
@@ -226,9 +225,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
         <hr>
       </div>
       <div class="sixteen columns">
-        <p class="center"><p>For more motivation on why to use Karma and why we did it, check out
-the blog post on <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.</p>
-
+        <p>
+          For more motivation on why to use Karma and why we did it, check out the blog post on
+          <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.
         </p>
       </div>
     </div>

--- a/0.6/index.html
+++ b/0.6/index.html
@@ -140,12 +140,12 @@
         <p class="bold large center">Things should be simple. We believe in testing and so we want to make it as simple as possible.</p>
       </div>
       <div class="sixteen columns bottom">
-        <p class="center"><p>The main goal for Karma is to bring a productive testing
-environment to developers. The environment being one where they don&#39;t have
-to set up loads of configurations, but rather a place where developers can just write the
-code and get instant feedback from their tests. Because getting quick feedback is what makes you
-productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
-
+        <p>
+          The main goal for Karma is to bring a productive testing
+          environment to developers. The environment being one where they don&#39;t have
+          to set up loads of configurations, but rather a place where developers can just write the
+          code and get instant feedback from their tests. Because getting quick feedback is what makes you
+          productive and <a href="http://vimeo.com/36579366">creative</a>.
         </p>
       </div>
       <div class="clearfix"></div>
@@ -170,17 +170,17 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column">
             <div class="icon-box"><i class="icon-globe icon-2x"></i></div>
             <h3>Testing Framework Agnostic</h3>
-            <p><p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
-<a href="http://mochajs.org/">Mocha</a>,
-<a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.</p>
-
+            <p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
+              <a href="http://mochajs.org/">Mocha</a>,
+              <a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.
             </p>
           </li>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-group icon-2x"></i></div>
             <h3>Open Source</h3>
-            <p><p>Developed for and maintained by the open source community at <a href="https://github.com/karma-runner/karma">GitHub</a>.</p>
-
+            <p>
+              Developed for and maintained by the open source community at
+              <a href="https://github.com/karma-runner/karma">GitHub</a>.
             </p>
           </li>
           <li class="one-third column last">
@@ -191,10 +191,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-refresh icon-2x"></i></div>
             <h3>Continuous Integration</h3>
-            <p><p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
-<a href="plus/travis.html">Travis</a> or
-<a href="plus/semaphore.html">Semaphore</a>.</p>
-
+            <p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
+              <a href="plus/travis.html">Travis</a> or
+              <a href="plus/semaphore.html">Semaphore</a>.
             </p>
           </li>
         </ul>
@@ -218,9 +217,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
         <hr>
       </div>
       <div class="sixteen columns">
-        <p class="center"><p>For more motivation on why to use Karma and why we did it, check out
-the blog post on <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.</p>
-
+        <p>
+          For more motivation on why to use Karma and why we did it, check out the blog post on
+          <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.
         </p>
       </div>
     </div>

--- a/0.8/index.html
+++ b/0.8/index.html
@@ -141,12 +141,12 @@
         <p class="bold large center">Things should be simple. We believe in testing and so we want to make it as simple as possible.</p>
       </div>
       <div class="sixteen columns bottom">
-        <p class="center"><p>The main goal for Karma is to bring a productive testing
-environment to developers. The environment being one where they don&#39;t have
-to set up loads of configurations, but rather a place where developers can just write the
-code and get instant feedback from their tests. Because getting quick feedback is what makes you
-productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
-
+        <p>
+          The main goal for Karma is to bring a productive testing
+          environment to developers. The environment being one where they don&#39;t have
+          to set up loads of configurations, but rather a place where developers can just write the
+          code and get instant feedback from their tests. Because getting quick feedback is what makes you
+          productive and <a href="http://vimeo.com/36579366">creative</a>.
         </p>
       </div>
       <div class="clearfix"></div>
@@ -171,17 +171,17 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column">
             <div class="icon-box"><i class="icon-globe icon-2x"></i></div>
             <h3>Testing Framework Agnostic</h3>
-            <p><p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
-<a href="http://mochajs.org/">Mocha</a>,
-<a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.</p>
-
+            <p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
+              <a href="http://mochajs.org/">Mocha</a>,
+              <a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.
             </p>
           </li>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-group icon-2x"></i></div>
             <h3>Open Source</h3>
-            <p><p>Developed for and maintained by the open source community at <a href="https://github.com/karma-runner/karma">GitHub</a>.</p>
-
+            <p>
+              Developed for and maintained by the open source community at
+              <a href="https://github.com/karma-runner/karma">GitHub</a>.
             </p>
           </li>
           <li class="one-third column last">
@@ -192,10 +192,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-refresh icon-2x"></i></div>
             <h3>Continuous Integration</h3>
-            <p><p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
-<a href="plus/travis.html">Travis</a> or
-<a href="plus/semaphore.html">Semaphore</a>.</p>
-
+            <p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
+              <a href="plus/travis.html">Travis</a> or
+              <a href="plus/semaphore.html">Semaphore</a>.
             </p>
           </li>
         </ul>
@@ -219,9 +218,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
         <hr>
       </div>
       <div class="sixteen columns">
-        <p class="center"><p>For more motivation on why to use Karma and why we did it, check out
-the blog post on <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.</p>
-
+        <p>
+          For more motivation on why to use Karma and why we did it, check out the blog post on
+          <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.
         </p>
       </div>
     </div>

--- a/1.0/index.html
+++ b/1.0/index.html
@@ -148,12 +148,12 @@
         <p class="bold large center">Things should be simple. We believe in testing and so we want to make it as simple as possible.</p>
       </div>
       <div class="sixteen columns bottom">
-        <p class="center"><p>The main goal for Karma is to bring a productive testing
-environment to developers. The environment being one where they don&#39;t have
-to set up loads of configurations, but rather a place where developers can just write the
-code and get instant feedback from their tests. Because getting quick feedback is what makes you
-productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
-
+        <p>
+          The main goal for Karma is to bring a productive testing
+          environment to developers. The environment being one where they don&#39;t have
+          to set up loads of configurations, but rather a place where developers can just write the
+          code and get instant feedback from their tests. Because getting quick feedback is what makes you
+          productive and <a href="http://vimeo.com/36579366">creative</a>.
         </p>
       </div>
       <div class="clearfix"></div>
@@ -178,17 +178,17 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column">
             <div class="icon-box"><i class="icon-globe icon-2x"></i></div>
             <h3>Testing Framework Agnostic</h3>
-            <p><p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
-<a href="http://mochajs.org/">Mocha</a>,
-<a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.</p>
-
+            <p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
+              <a href="http://mochajs.org/">Mocha</a>,
+              <a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.
             </p>
           </li>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-group icon-2x"></i></div>
             <h3>Open Source</h3>
-            <p><p>Developed for and maintained by the open source community at <a href="https://github.com/karma-runner/karma">GitHub</a>.</p>
-
+            <p>
+              Developed for and maintained by the open source community at
+              <a href="https://github.com/karma-runner/karma">GitHub</a>.
             </p>
           </li>
           <li class="one-third column last">
@@ -199,10 +199,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-refresh icon-2x"></i></div>
             <h3>Continuous Integration</h3>
-            <p><p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
-<a href="plus/travis.html">Travis</a> or
-<a href="plus/semaphore.html">Semaphore</a>.</p>
-
+            <p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
+              <a href="plus/travis.html">Travis</a> or
+              <a href="plus/semaphore.html">Semaphore</a>.
             </p>
           </li>
         </ul>
@@ -226,9 +225,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
         <hr>
       </div>
       <div class="sixteen columns">
-        <p class="center"><p>For more motivation on why to use Karma and why we did it, check out
-the blog post on <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.</p>
-
+        <p>
+          For more motivation on why to use Karma and why we did it, check out the blog post on
+          <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.
         </p>
       </div>
     </div>

--- a/2.0/index.html
+++ b/2.0/index.html
@@ -148,12 +148,12 @@
         <p class="bold large center">Things should be simple. We believe in testing and so we want to make it as simple as possible.</p>
       </div>
       <div class="sixteen columns bottom">
-        <p class="center"><p>The main goal for Karma is to bring a productive testing
-environment to developers. The environment being one where they don&#39;t have
-to set up loads of configurations, but rather a place where developers can just write the
-code and get instant feedback from their tests. Because getting quick feedback is what makes you
-productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
-
+        <p>
+          The main goal for Karma is to bring a productive testing
+          environment to developers. The environment being one where they don&#39;t have
+          to set up loads of configurations, but rather a place where developers can just write the
+          code and get instant feedback from their tests. Because getting quick feedback is what makes you
+          productive and <a href="http://vimeo.com/36579366">creative</a>.
         </p>
       </div>
       <div class="clearfix"></div>
@@ -178,17 +178,17 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column">
             <div class="icon-box"><i class="icon-globe icon-2x"></i></div>
             <h3>Testing Framework Agnostic</h3>
-            <p><p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
-<a href="http://mochajs.org/">Mocha</a>,
-<a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.</p>
-
+            <p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
+              <a href="http://mochajs.org/">Mocha</a>,
+              <a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.
             </p>
           </li>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-group icon-2x"></i></div>
             <h3>Open Source</h3>
-            <p><p>Developed for and maintained by the open source community at <a href="https://github.com/karma-runner/karma">GitHub</a>.</p>
-
+            <p>
+              Developed for and maintained by the open source community at
+              <a href="https://github.com/karma-runner/karma">GitHub</a>.
             </p>
           </li>
           <li class="one-third column last">
@@ -199,10 +199,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-refresh icon-2x"></i></div>
             <h3>Continuous Integration</h3>
-            <p><p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
-<a href="plus/travis.html">Travis</a> or
-<a href="plus/semaphore.html">Semaphore</a>.</p>
-
+            <p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
+              <a href="plus/travis.html">Travis</a> or
+              <a href="plus/semaphore.html">Semaphore</a>.
             </p>
           </li>
         </ul>
@@ -226,9 +225,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
         <hr>
       </div>
       <div class="sixteen columns">
-        <p class="center"><p>For more motivation on why to use Karma and why we did it, check out
-the blog post on <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.</p>
-
+        <p>
+          For more motivation on why to use Karma and why we did it, check out the blog post on
+          <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.
         </p>
       </div>
     </div>

--- a/3.0/index.html
+++ b/3.0/index.html
@@ -148,12 +148,12 @@
         <p class="bold large center">Things should be simple. We believe in testing and so we want to make it as simple as possible.</p>
       </div>
       <div class="sixteen columns bottom">
-        <p class="center"><p>The main goal for Karma is to bring a productive testing
-environment to developers. The environment being one where they don&#39;t have
-to set up loads of configurations, but rather a place where developers can just write the
-code and get instant feedback from their tests. Because getting quick feedback is what makes you
-productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
-
+        <p>
+          The main goal for Karma is to bring a productive testing
+          environment to developers. The environment being one where they don&#39;t have
+          to set up loads of configurations, but rather a place where developers can just write the
+          code and get instant feedback from their tests. Because getting quick feedback is what makes you
+          productive and <a href="http://vimeo.com/36579366">creative</a>.
         </p>
       </div>
       <div class="clearfix"></div>
@@ -178,17 +178,17 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column">
             <div class="icon-box"><i class="icon-globe icon-2x"></i></div>
             <h3>Testing Framework Agnostic</h3>
-            <p><p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
-<a href="http://mochajs.org/">Mocha</a>,
-<a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.</p>
-
+            <p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
+              <a href="http://mochajs.org/">Mocha</a>,
+              <a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.
             </p>
           </li>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-group icon-2x"></i></div>
             <h3>Open Source</h3>
-            <p><p>Developed for and maintained by the open source community at <a href="https://github.com/karma-runner/karma">GitHub</a>.</p>
-
+            <p>
+              Developed for and maintained by the open source community at
+              <a href="https://github.com/karma-runner/karma">GitHub</a>.
             </p>
           </li>
           <li class="one-third column last">
@@ -199,10 +199,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-refresh icon-2x"></i></div>
             <h3>Continuous Integration</h3>
-            <p><p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
-<a href="plus/travis.html">Travis</a> or
-<a href="plus/semaphore.html">Semaphore</a>.</p>
-
+            <p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
+              <a href="plus/travis.html">Travis</a> or
+              <a href="plus/semaphore.html">Semaphore</a>.
             </p>
           </li>
         </ul>
@@ -226,9 +225,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
         <hr>
       </div>
       <div class="sixteen columns">
-        <p class="center"><p>For more motivation on why to use Karma and why we did it, check out
-the blog post on <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.</p>
-
+        <p>
+          For more motivation on why to use Karma and why we did it, check out the blog post on
+          <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.
         </p>
       </div>
     </div>

--- a/4.0/index.html
+++ b/4.0/index.html
@@ -148,12 +148,12 @@
         <p class="bold large center">Things should be simple. We believe in testing and so we want to make it as simple as possible.</p>
       </div>
       <div class="sixteen columns bottom">
-        <p class="center"><p>The main goal for Karma is to bring a productive testing
-environment to developers. The environment being one where they don&#39;t have
-to set up loads of configurations, but rather a place where developers can just write the
-code and get instant feedback from their tests. Because getting quick feedback is what makes you
-productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
-
+        <p>
+          The main goal for Karma is to bring a productive testing
+          environment to developers. The environment being one where they don&#39;t have
+          to set up loads of configurations, but rather a place where developers can just write the
+          code and get instant feedback from their tests. Because getting quick feedback is what makes you
+          productive and <a href="http://vimeo.com/36579366">creative</a>.
         </p>
       </div>
       <div class="clearfix"></div>
@@ -178,17 +178,17 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column">
             <div class="icon-box"><i class="icon-globe icon-2x"></i></div>
             <h3>Testing Framework Agnostic</h3>
-            <p><p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
-<a href="http://mochajs.org/">Mocha</a>,
-<a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.</p>
-
+            <p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
+              <a href="http://mochajs.org/">Mocha</a>,
+              <a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.
             </p>
           </li>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-group icon-2x"></i></div>
             <h3>Open Source</h3>
-            <p><p>Developed for and maintained by the open source community at <a href="https://github.com/karma-runner/karma">GitHub</a>.</p>
-
+            <p>
+              Developed for and maintained by the open source community at
+              <a href="https://github.com/karma-runner/karma">GitHub</a>.
             </p>
           </li>
           <li class="one-third column last">
@@ -199,10 +199,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-refresh icon-2x"></i></div>
             <h3>Continuous Integration</h3>
-            <p><p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
-<a href="plus/travis.html">Travis</a> or
-<a href="plus/semaphore.html">Semaphore</a>.</p>
-
+            <p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
+              <a href="plus/travis.html">Travis</a> or
+              <a href="plus/semaphore.html">Semaphore</a>.
             </p>
           </li>
         </ul>
@@ -226,9 +225,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
         <hr>
       </div>
       <div class="sixteen columns">
-        <p class="center"><p>For more motivation on why to use Karma and why we did it, check out
-the blog post on <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.</p>
-
+        <p>
+          For more motivation on why to use Karma and why we did it, check out the blog post on
+          <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.
         </p>
       </div>
     </div>

--- a/5.0/index.html
+++ b/5.0/index.html
@@ -144,12 +144,12 @@
         <p class="bold large center">Things should be simple. We believe in testing and so we want to make it as simple as possible.</p>
       </div>
       <div class="sixteen columns bottom">
-        <p class="center"><p>The main goal for Karma is to bring a productive testing
-environment to developers. The environment being one where they don&#39;t have
-to set up loads of configurations, but rather a place where developers can just write the
-code and get instant feedback from their tests. Because getting quick feedback is what makes you
-productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
-
+        <p>
+          The main goal for Karma is to bring a productive testing
+          environment to developers. The environment being one where they don&#39;t have
+          to set up loads of configurations, but rather a place where developers can just write the
+          code and get instant feedback from their tests. Because getting quick feedback is what makes you
+          productive and <a href="http://vimeo.com/36579366">creative</a>.
         </p>
       </div>
       <div class="clearfix"></div>
@@ -174,17 +174,17 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column">
             <div class="icon-box"><i class="icon-globe icon-2x"></i></div>
             <h3>Testing Framework Agnostic</h3>
-            <p><p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
-<a href="http://mochajs.org/">Mocha</a>,
-<a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.</p>
-
+            <p>Describe your tests with <a href="http://jasmine.github.io/">Jasmine</a>,
+              <a href="http://mochajs.org/">Mocha</a>,
+              <a href="http://qunitjs.com/">QUnit</a>, or write a simple adapter for any framework you like.
             </p>
           </li>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-group icon-2x"></i></div>
             <h3>Open Source</h3>
-            <p><p>Developed for and maintained by the open source community at <a href="https://github.com/karma-runner/karma">GitHub</a>.</p>
-
+            <p>
+              Developed for and maintained by the open source community at
+              <a href="https://github.com/karma-runner/karma">GitHub</a>.
             </p>
           </li>
           <li class="one-third column last">
@@ -195,10 +195,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
           <li class="one-third column last">
             <div class="icon-box"><i class="icon-refresh icon-2x"></i></div>
             <h3>Continuous Integration</h3>
-            <p><p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
-<a href="plus/travis.html">Travis</a> or
-<a href="plus/semaphore.html">Semaphore</a>.</p>
-
+            <p>Simple integration with <a href="plus/jenkins.html">Jenkins</a>,
+              <a href="plus/travis.html">Travis</a> or
+              <a href="plus/semaphore.html">Semaphore</a>.
             </p>
           </li>
         </ul>
@@ -222,9 +221,9 @@ productive and <a href="http://vimeo.com/36579366">creative</a>.</p>
         <hr>
       </div>
       <div class="sixteen columns">
-        <p class="center"><p>For more motivation on why to use Karma and why we did it, check out
-the blog post on <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.</p>
-
+        <p>
+          For more motivation on why to use Karma and why we did it, check out the blog post on
+          <a href="http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html">Google Testing</a>.
         </p>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "grunt-contrib-watch": "1.1.0",
     "grunt-eslint": "21.0.0",
     "jade": "1.11.0",
-    "jstransformer-marked": "1.0.3",
     "load-grunt-tasks": "4.0.0",
     "marked": "0.5.1",
     "namp": "0.2.25",

--- a/src/jade/homepage.jade
+++ b/src/jade/homepage.jade
@@ -46,14 +46,12 @@ block content
       p.bold.large.center.
         Things should be simple. We believe in testing and so we want to make it as simple as possible.
     .sixteen.columns.bottom
-      p.center
-        :marked
-          The main goal for Karma is to bring a productive testing
-          environment to developers. The environment being one where they don&#39;t have
-          to set up loads of configurations, but rather a place where developers can just write the
-          code and get instant feedback from their tests. Because getting quick feedback is what makes you
-          productive and [creative](http://vimeo.com/36579366).
-
+      p.
+        The main goal for Karma is to bring a productive testing
+        environment to developers. The environment being one where they don&#39;t have
+        to set up loads of configurations, but rather a place where developers can just write the
+        code and get instant feedback from their tests. Because getting quick feedback is what makes you
+        productive and #[a(href='http://vimeo.com/36579366') creative].
     .clearfix
     .our-services
       ul
@@ -75,19 +73,17 @@ block content
           .icon-box
             i.icon-globe.icon-2x
           h3 Testing Framework Agnostic
-          p
-            :marked
-              Describe your tests with [Jasmine](http://jasmine.github.io/),
-              [Mocha](http://mochajs.org/),
-              [QUnit](http://qunitjs.com/), or write a simple adapter for any framework you like.
-
+          p.
+            Describe your tests with #[a(href='http://jasmine.github.io/') Jasmine],
+            #[a(href='http://mochajs.org/') Mocha],
+            #[a(href='http://qunitjs.com/') QUnit], or write a simple adapter for any framework you like.
         li.one-third.column.last
           .icon-box
             i.icon-group.icon-2x
           h3 Open Source
-          p
-            :marked
-              Developed for and maintained by the open source community at [GitHub](https://github.com/karma-runner/karma).
+          p.
+            Developed for and maintained by the open source community at
+            #[a(href='https://github.com/karma-runner/karma') GitHub].
         li.one-third.column.last
           .icon-box
             i.icon-magic.icon-2x
@@ -98,12 +94,10 @@ block content
           .icon-box
             i.icon-refresh.icon-2x
           h3 Continuous Integration
-          p
-            :marked
-              Simple integration with [Jenkins](plus/jenkins.html),
-              [Travis](plus/travis.html) or
-              [Semaphore](plus/semaphore.html).
-
+          p.
+            Simple integration with #[a(href='plus/jenkins.html') Jenkins],
+            #[a(href='plus/travis.html') Travis] or
+            #[a(href='plus/semaphore.html') Semaphore].
   .container
     .sixteen.columns.bottom
       p.bold.large.center.
@@ -115,7 +109,6 @@ block content
     .sixteen.columns.bottom
       hr
     .sixteen.columns
-      p.center
-        :marked
-          For more motivation on why to use Karma and why we did it, check out
-          the blog post on [Google Testing](http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html).
+      p.
+        For more motivation on why to use Karma and why we did it, check out the blog post on
+        #[a(href='http://googletesting.blogspot.com/2012/11/testacular-spectacular-test-runner-for.html') Google Testing].

--- a/yarn.lock
+++ b/yarn.lock
@@ -1459,12 +1459,6 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jstransformer-marked@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/jstransformer-marked/-/jstransformer-marked-1.0.3.tgz#07ce849d95a3c4e398f2dfd90d94be3b88453f16"
-  dependencies:
-    marked "^0.3.9"
-
 jstransformer@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/jstransformer/-/jstransformer-0.0.2.tgz#7aae29a903d196cfa0973d885d3e47947ecd76ab"
@@ -1581,10 +1575,6 @@ map-obj@^1.0.0, map-obj@^1.0.1:
 marked@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.5.1.tgz#062f43b88b02ee80901e8e8d8e6a620ddb3aa752"
-
-marked@^0.3.9:
-  version "0.3.19"
-  resolved "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
 
 maxmin@^2.1.0:
   version "2.1.0"
@@ -2358,7 +2348,9 @@ string-width@^2.1.0, string-width@^2.1.1:
     strip-ansi "^4.0.0"
 
 string_decoder@0.10:
-  version "0.0.0"
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
GitHub is not good at rendering diff here, but the change is whitespaces and removed `<p></p>` nesting, which is invalid HTML.