### PR TITLE
chore: Remove custom code tag renderer

### DIFF
--- a/0.10/about/changelog.html
+++ b/0.10/about/changelog.html
@@ -323,7 +323,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -368,7 +369,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/0.10/about/migration.html
+++ b/0.10/about/migration.html
@@ -127,10 +127,12 @@
 npm install karma
 
 <span class="hljs-comment"># or upgrade global install...</span>
-sudo npm install -g karma</code></pre>
+sudo npm install -g karma
+</code></pre>
 <h2>Plugins</h2>
 <p>All the frameworks, reporters, preprocessors and browser launchers are now separate plugins. Here is a list of all of them including related plugins. So install all the plugins you need:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h3>Frameworks</h3>
 <ul>
 <li>jasmine (<code>karma-jasmine</code> ships with Karma)</li>
@@ -171,7 +173,8 @@ sudo npm install -g karma</code></pre>
       <span class="hljs-comment">// ...</span>
     ]
   })
-};</code></pre>
+};
+</code></pre>
 <p>Also, remove all the constants like <code>JASMINE</code>, <code>JASMINE_ADAPTER</code>, <code>MOCHA</code>, <code>MOCHA_ADAPTER</code>, <code>QUNIT</code>, <code>QUNIT_ADAPTER</code>, <code>REQUIRE</code>, <code>REQUIRE_ADAPTER</code>, <code>ANGULAR_SCENARIO</code>, <code>ANGULAR_SCENARIO_ADAPTER</code> from files and use frameworks config instead:</p>
 <pre><code class="language-javascript"><span class="hljs-comment">// before</span>
 files = [
@@ -186,7 +189,8 @@ files = [
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-attr">files</span>: [<span class="hljs-string">'*.js'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>That should be it ;-) If you have any problem, ask on <a href="https://groups.google.com/forum/?fromgroups#!forum/karma-users">mailing list</a>.</p>
 <p>You can also check out <a href="https://github.com/angular/angular.js/commit/29f96c852c355d0e283a64111d4923d1bcde8f5f">migrating AngularJS</a>.</p>
 

--- a/0.10/about/versioning.html
+++ b/0.10/about/versioning.html
@@ -128,11 +128,14 @@
   <span class="hljs-string">"devDependencies"</span>: {
     <span class="hljs-string">"karma"</span>: <span class="hljs-string">"~0.10"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Stable channel (branch <code>stable</code>)</h2>
-<pre><code class="language-bash">$ npm install karma</code></pre>
+<pre><code class="language-bash">$ npm install karma
+</code></pre>
 <h2>Canary channel (branch <code>master</code>)</h2>
-<pre><code class="language-bash">$ npm install karma@canary</code></pre>
+<pre><code class="language-bash">$ npm install karma@canary
+</code></pre>
 
         </div>
       </div>

--- a/0.10/config/browsers.html
+++ b/0.10/config/browsers.html
@@ -120,7 +120,8 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own is kinda tedious and time consuming,
 so Karma can do that for you. Just simply add into the configuration file:</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of autocapturing these browsers, as well as killing them.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers needs to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -140,13 +141,15 @@ so Karma can do that for you. Just simply add into the configuration file:</p>
 simply install the required launcher first using NPM and then assign the browser setting within the configuration file using the <code>browsers</code>.</p>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -156,7 +159,8 @@ $ npm install karma-firefox-launcher --save-dev</code></pre>
 <p>Some of the launchers can be also configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -168,7 +172,8 @@ $ npm install karma-firefox-launcher --save-dev</code></pre>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
 You can override these settings by <code>&lt;BROWSER&gt;_BIN</code> ENV variable, or alternatively by creating a <code>symlink</code>.</p>
@@ -180,17 +185,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID
 parameter to be used to connect to the server. The supplied ID is used
 by the server to keep track of which specific browser is captured.</p>

--- a/0.10/config/configuration-file.html
+++ b/0.10/config/configuration-file.html
@@ -132,13 +132,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># an example karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <p>To see a more detailed example configuration file, see <a href="https://github.com/karma-runner/karma/blob/master/test/client/karma.conf.js">test/client/karma.conf.js</a> which contains most of
 the available configuration options.</p>
 <h2>File Patterns</h2>
@@ -277,7 +279,8 @@ but your interactive debugging does not.</p>
 <pre><code class="language-javascript">proxies:  {
   <span class="hljs-string">'/static'</span>: <span class="hljs-string">'http://gstatic.com'</span>,
   <span class="hljs-string">'/web'</span>: <span class="hljs-string">'http://localhost:9000'</span>
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong>   <code>true</code></p>

--- a/0.10/config/files.html
+++ b/0.10/config/files.html
@@ -180,7 +180,8 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file only gets watched but otherwise ignored</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'app/index.html'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 
         </div>
       </div>

--- a/0.10/config/plugins.html
+++ b/0.10/config/plugins.html
@@ -129,9 +129,11 @@ In fact, all the existing preprocessors, reporters, browser launchers and framew
     <span class="hljs-string">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-string">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way how to install a plugin is</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads all NPM modules that are siblinks to it and their name matches <code>karma-*</code>.</p>
 <p>You can also explicitly list plugins you want to load via the <code>plugins</code> configuration setting. The configuration value can either be
@@ -144,7 +146,8 @@ a string (module name), which will be required by Karma, or an object (inlined p
   <span class="hljs-comment">// inelined plugins</span>
   {<span class="hljs-string">'framework:xyz'</span>, [<span class="hljs-string">'factory'</span>, factoryFn]},
   <span class="hljs-built_in">require</span>(<span class="hljs-string">'./plugin-required-from-config'</span>)
-]</code></pre>
+]
+</code></pre>
 <p>There are already many <a href="https://npmjs.org/browse/keyword/karma-plugin">existing plugins</a>. Of course, you write <a href="../dev/plugins.html">your own plugins</a> too!</p>
 
         </div>

--- a/0.10/config/preprocessors.html
+++ b/0.10/config/preprocessors.html
@@ -125,7 +125,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <p>Note the multiple expressions referencing the &quot;coffee&quot; preprocessor, as a preprocessor can be listed more than once,
 as another way to specify multiple file path expressions.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -149,7 +150,8 @@ as another way to specify multiple file path expressions.</p>
 simply install the required NPM library first and the installed preprocessor can be used regularly.</p>
 <p>Here&#39;s an example of how to add the coverage preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coverage --save-dev</code></pre>
+$ npm install karma-coverage --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -157,7 +159,8 @@ $ npm install karma-coverage --save-dev</code></pre>
       <span class="hljs-string">'**/*.js'</span>: [<span class="hljs-string">'coverage'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can be also configured:</p>
@@ -165,14 +168,16 @@ $ npm install karma-coverage --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Minimatching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>

--- a/0.10/dev/contributing.html
+++ b/0.10/dev/contributing.html
@@ -133,11 +133,13 @@ already exist.<ul>
 </ul>
 <h2>Making Changes</h2>
 <ul>
-<li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> git@github.com:&lt;your-username&gt;/karma.git</code></pre>
+<li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> git@github.com:&lt;your-username&gt;/karma.git
+</code></pre>
 </li>
 <li>Init your workspace</li>
 </ul>
-<pre><code class="language-bash">$ ./scripts/init-dev-env.js</code></pre>
+<pre><code class="language-bash">$ ./scripts/init-dev-env.js
+</code></pre>
 <ul>
 <li>Checkout a new branch (usually based on <code>master</code>) and name it accordingly to what
 you intend to do<ul>
@@ -154,11 +156,14 @@ $ grunt <span class="hljs-built_in">test</span>
 
 $ grunt <span class="hljs-built_in">test</span>:unit
 $ grunt <span class="hljs-built_in">test</span>:e2e
-$ grunt <span class="hljs-built_in">test</span>:client</code></pre>
+$ grunt <span class="hljs-built_in">test</span>:client
+</code></pre>
 <p>Lint the files via</p>
-<pre><code class="language-bash">$ grunt lint</code></pre>
+<pre><code class="language-bash">$ grunt lint
+</code></pre>
 <p>Build the project via</p>
-<pre><code class="language-bash">$ grunt build</code></pre>
+<pre><code class="language-bash">$ grunt build
+</code></pre>
 <p>The default task, just calling <code>grunt</code> will run <code>build lint test</code>.</p>
 <p>If grunt fails, make sure grunt-0.4x is installed: <a href="https://github.com/gruntjs/grunt/wiki/Getting-started">https://github.com/gruntjs/grunt/wiki/Getting-started</a>.</p>
 <h2>Submitting Changes</h2>

--- a/0.10/dev/git-commit-msg.html
+++ b/0.10/dev/git-commit-msg.html
@@ -128,7 +128,8 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>First line cannot be longer than 70 characters, second line is always
 blank and other lines should be wrapped at 80 characters.</p>
@@ -168,9 +169,11 @@ omitted.</p>
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -180,7 +183,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>.</p>
 

--- a/0.10/dev/public-api.html
+++ b/0.10/dev/public-api.html
@@ -127,7 +127,8 @@ You can, however, call Karma programmatically from your node module. Here is the
 server.start({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode);
   process.exit(exitCode);
-});</code></pre>
+});
+</code></pre>
 <h2>karma.runner</h2>
 <h3><strong>runner.run(options, [callback=process.exit])</strong></h3>
 <p>Equivalent of <code>karma run</code>.</p>
@@ -135,7 +136,8 @@ server.start({<span class="hljs-attr">port</span>: <span class="hljs-number">987
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode);
   process.exit(exitCode);
-});</code></pre>
+});
+</code></pre>
 
         </div>
       </div>

--- a/0.10/intro/configuration.html
+++ b/0.10/intro/configuration.html
@@ -156,7 +156,8 @@ Do you want Karma to watch all the files and run the tests on change ?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>.coffee</code> filename extension, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy paste it from another project ;-)</p>
@@ -164,13 +165,15 @@ In fact, if you execute <code>karma init</code> with a <code>.coffee</code> file
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start karma-conf.js --<span class="hljs-built_in">command</span>-one --<span class="hljs-built_in">command</span>-two</code></pre>
+<pre><code class="language-bash">karma start karma-conf.js --<span class="hljs-built_in">command</span>-one --<span class="hljs-built_in">command</span>-two
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Using Grunt</h2>
 <p>If you are using <a href="http://gruntjs.com/">Grunt</a> within your project,

--- a/0.10/intro/installation.html
+++ b/0.10/intro/installation.html
@@ -144,15 +144,18 @@
 command from any directory. This means that the <code>karma</code> command (which is the central command that Karma uses to run
 tests) can be executed anywhere via the command line.</p>
 <p>The following command will install Karma globally:</p>
-<pre><code class="language-bash">$ npm install -g karma</code></pre>
+<pre><code class="language-bash">$ npm install -g karma
+</code></pre>
 <p>Please note, that the <code>karma</code> command will always look for a locally installed instance of Karma first and
 before resorting to a global install and, if present, then the local version will be utilized.
 This allows you to use different version of Karma per project.</p>
 <h2>Local Installation</h2>
 <p>A local installation will install Karma into your current directory&#39;s <code>node_modules</code>.</p>
-<pre><code class="language-bash">$ npm install karma --save-dev</code></pre>
+<pre><code class="language-bash">$ npm install karma --save-dev
+</code></pre>
 <p>The karma command can now be also executed directly from the node_modules directory:</p>
-<pre><code class="language-bash">$ ./node_modules/.bin/karma</code></pre>
+<pre><code class="language-bash">$ ./node_modules/.bin/karma
+</code></pre>
 
         </div>
       </div>

--- a/0.10/plus/cloud9.html
+++ b/0.10/plus/cloud9.html
@@ -124,11 +124,13 @@ It is written almost entirely in JavaScript, and uses NodeJS on the back-end.</p
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -136,7 +138,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/0.10/plus/emberjs.html
+++ b/0.10/plus/emberjs.html
@@ -123,13 +123,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -160,16 +163,19 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 </li>
 <li><p>add a simple qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/0.10/plus/jenkins.html
+++ b/0.10/plus/jenkins.html
@@ -141,7 +141,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-result.xml</code> file will be written to the present
 working directory (and you will need to tell Jenkins where to find it).</p>
 <h2>Create a new Jenkins Job</h2>
@@ -154,7 +155,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process” checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/0.10/plus/requirejs.html
+++ b/0.10/plus/requirejs.html
@@ -139,11 +139,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks works just
@@ -182,7 +184,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this is <code>test/test-main.js</code>.</p>
@@ -233,7 +236,8 @@ requirejs.config({
 
     <span class="hljs-comment">// start test run, once Require.js is done</span>
     <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -258,14 +262,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/0.10/plus/semaphore.html
+++ b/0.10/plus/semaphore.html
@@ -135,19 +135,22 @@ make it easy to run your tests. Here&#39;s an example:</p>
 <span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/.bin/karma start --single-run --browsers PhantomJS'</span>
 }
-<span class="hljs-comment">// ...snip...</span></code></pre>
+<span class="hljs-comment">// ...snip...</span>
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
 <pre><code class="language-javascript"><span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/.bin/karma start --single-run --browsers Firefox'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreapp.com/">screencast</a> on the Semaphore homepage.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it in a virtual screen
 during your builds.</p>

--- a/0.10/plus/travis.html
+++ b/0.10/plus/travis.html
@@ -130,7 +130,8 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-number">0</span>.<span class="hljs-number">8</span></code></pre>
+  - <span class="hljs-number">0</span>.<span class="hljs-number">8</span>
+</code></pre>
 <h2>Setup a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root
 create one now. Travis runs <code>npm test</code> to trigger your tests so this
@@ -143,7 +144,8 @@ is where you tell Travis how to run your tests.</p>
 <span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/.bin/karma start --single-run --browsers PhantomJS'</span>
 }
-<span class="hljs-comment">// ...snip...</span></code></pre>
+<span class="hljs-comment">// ...snip...</span>
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -156,10 +158,12 @@ like this:</p>
   - <span class="hljs-number">0</span>.<span class="hljs-number">8</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">./node_modules/.bin/karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">./node_modules/.bin/karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/0.12/about/changelog.html
+++ b/0.12/about/changelog.html
@@ -748,7 +748,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -793,7 +794,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/0.12/about/migration.html
+++ b/0.12/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/0.12/about/versioning.html
+++ b/0.12/about/versioning.html
@@ -133,11 +133,14 @@
   <span class="hljs-string">"devDependencies"</span>: {
     <span class="hljs-string">"karma"</span>: <span class="hljs-string">"~0.10"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Stable channel (branch <code>stable</code>)</h2>
-<pre><code class="language-bash">$ npm install karma</code></pre>
+<pre><code class="language-bash">$ npm install karma
+</code></pre>
 <h2>Canary channel (branch <code>master</code>)</h2>
-<pre><code class="language-bash">$ npm install karma@canary</code></pre>
+<pre><code class="language-bash">$ npm install karma@canary
+</code></pre>
 
         </div>
       </div>

--- a/0.12/config/browsers.html
+++ b/0.12/config/browsers.html
@@ -126,7 +126,8 @@
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time consuming task,
 so Karma can automate this for you. Simply add the browsers you would like to
 capture into the configuration file:</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -143,13 +144,15 @@ capture into the configuration file:</p>
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -162,7 +165,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can be also configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -174,7 +178,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
 You can override these settings by <code>&lt;BROWSER&gt;_BIN</code> ENV variable, or alternatively by creating a <code>symlink</code>.</p>
@@ -186,17 +191,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID
 parameter to be used to connect to the server. The supplied ID is used
 by the server to keep track of which specific browser is captured.</p>

--- a/0.12/config/configuration-file.html
+++ b/0.12/config/configuration-file.html
@@ -138,13 +138,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -309,7 +311,8 @@ but your interactive debugging does not.</p>
 <pre><code class="language-javascript">proxies: {
 <span class="hljs-string">'/static'</span>: <span class="hljs-string">'http://gstatic.com'</span>,
 <span class="hljs-string">'/web'</span>: <span class="hljs-string">'http://localhost:9000'</span>
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>

--- a/0.12/config/files.html
+++ b/0.12/config/files.html
@@ -189,26 +189,30 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file only gets watched and is otherwise ignored</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'app/index.html'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading Assets</h2>
 <p>By default all assets are served at <code>http://localhost:[PORT]/base/</code></p>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">"test/images/*.jpg"</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 
         </div>
       </div>

--- a/0.12/config/plugins.html
+++ b/0.12/config/plugins.html
@@ -134,9 +134,11 @@ In fact, all the existing preprocessors, reporters, browser launchers and framew
     <span class="hljs-string">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-string">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads all sibling NPM modules which have a name starting with <code>karma-*</code>.</p>
 <p>You can also explicitly list plugins you want to load via the <code>plugins</code> configuration setting. The configuration value can either be
@@ -149,7 +151,8 @@ a string (module name), which will be required by Karma, or an object (inlined p
   <span class="hljs-comment">// inlined plugins</span>
   {<span class="hljs-string">'framework:xyz'</span>, [<span class="hljs-string">'factory'</span>, factoryFn]},
   <span class="hljs-built_in">require</span>(<span class="hljs-string">'./plugin-required-from-config'</span>)
-]</code></pre>
+]
+</code></pre>
 <p>There are already many <a href="https://npmjs.org/browse/keyword/karma-plugin">existing plugins</a>. Of course, you can write <a href="../dev/plugins.html">your own plugins</a> too!</p>
 
         </div>

--- a/0.12/config/preprocessors.html
+++ b/0.12/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can be also configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Minimatching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>

--- a/0.12/dev/git-commit-msg.html
+++ b/0.12/dev/git-commit-msg.html
@@ -133,7 +133,8 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>First line cannot be longer than 70 characters, second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -174,9 +175,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -186,7 +189,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/0.12/dev/making-changes.html
+++ b/0.12/dev/making-changes.html
@@ -139,9 +139,11 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork.<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> git@github.com:&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
-<li>Init the workspace<pre><code class="language-bash">$ ./scripts/init-dev-env.js</code></pre>
+<li>Init the workspace<pre><code class="language-bash">$ ./scripts/init-dev-env.js
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -152,13 +154,16 @@ $ grunt <span class="hljs-built_in">test</span>:e2e
 $ grunt <span class="hljs-built_in">test</span>:client
 
 <span class="hljs-comment"># All tests.</span>
-$ grunt <span class="hljs-built_in">test</span></code></pre>
+$ grunt <span class="hljs-built_in">test</span>
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
-<pre><code class="language-bash">$ grunt lint</code></pre>
+<pre><code class="language-bash">$ grunt lint
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
-<pre><code class="language-bash">$ grunt build</code></pre>
+<pre><code class="language-bash">$ grunt build
+</code></pre>
 </li>
 </ul>
 <p>The default task, just calling <code>grunt</code> will run <code>build lint test</code>.</p>
@@ -167,7 +172,8 @@ $ grunt <span class="hljs-built_in">test</span></code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -177,9 +183,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/0.12/dev/plugins.html
+++ b/0.12/dev/plugins.html
@@ -181,7 +181,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 
         </div>
       </div>

--- a/0.12/dev/public-api.html
+++ b/0.12/dev/public-api.html
@@ -132,7 +132,8 @@ You can, however, call Karma programmatically from your node module. Here is the
 server.start({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode);
   process.exit(exitCode);
-});</code></pre>
+});
+</code></pre>
 <h2>karma.runner</h2>
 <h3><strong>runner.run(options, [callback=process.exit])</strong></h3>
 <p>Equivalent of <code>karma run</code>.</p>
@@ -140,7 +141,8 @@ server.start({<span class="hljs-attr">port</span>: <span class="hljs-number">987
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode);
   process.exit(exitCode);
-});</code></pre>
+});
+</code></pre>
 
         </div>
       </div>

--- a/0.12/intro/configuration.html
+++ b/0.12/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change ?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/0.12/intro/installation.html
+++ b/0.12/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/0.12/plus/cloud9.html
+++ b/0.12/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript, and uses NodeJS on the back-end.</p
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/0.12/plus/codio.html
+++ b/0.12/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from right button).</p>

--- a/0.12/plus/emberjs.html
+++ b/0.12/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/0.12/plus/jenkins.html
+++ b/0.12/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-result.xml</code> file will be written to the present
 working directory (and you will need to tell Jenkins where to find it).</p>
 <h2>Create a new Jenkins Job</h2>
@@ -159,7 +160,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/0.12/plus/requirejs.html
+++ b/0.12/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks works just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this is <code>test/test-main.js</code>.</p>
@@ -267,7 +271,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -294,14 +299,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/0.12/plus/semaphore.html
+++ b/0.12/plus/semaphore.html
@@ -140,19 +140,22 @@ make it easy to run your tests. Here&#39;s an example:</p>
 <span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/.bin/karma start --single-run --browsers PhantomJS'</span>
 }
-<span class="hljs-comment">// ...snip...</span></code></pre>
+<span class="hljs-comment">// ...snip...</span>
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
 <pre><code class="language-javascript"><span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/.bin/karma start --single-run --browsers Firefox'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreapp.com/">screencast</a> on the Semaphore homepage.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it in a virtual screen
 during your builds.</p>

--- a/0.12/plus/teamcity.html
+++ b/0.12/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomja-launcher</code> and so on) to have them
 being installed during build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to build configuration: use Command Line runner and fill in <code>Custom script</code> textarea. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> in the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/0.12/plus/travis.html
+++ b/0.12/plus/travis.html
@@ -135,7 +135,8 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"0.10"</span></code></pre>
+  - <span class="hljs-string">"0.10"</span>
+</code></pre>
 <h2>Setup a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root
 create one now. Travis runs <code>npm test</code> to trigger your tests so this
@@ -148,7 +149,8 @@ is where you tell Travis how to run your tests.</p>
 <span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/karma/bin/karma start --single-run --browsers PhantomJS'</span>
 }
-<span class="hljs-comment">// ...snip...</span></code></pre>
+<span class="hljs-comment">// ...snip...</span>
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -161,10 +163,12 @@ like this:</p>
   - <span class="hljs-string">"0.10"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/0.13/about/changelog.html
+++ b/0.13/about/changelog.html
@@ -349,10 +349,12 @@
 <ul>
 <li>The public api interface has changed to a constructor form. To upgrade
 change<pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 to<pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</li>
 </ul>
@@ -981,7 +983,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1026,7 +1029,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/0.13/about/migration.html
+++ b/0.13/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/0.13/about/versioning.html
+++ b/0.13/about/versioning.html
@@ -135,9 +135,11 @@ file, either manually</p>
   <span class="hljs-string">"devDependencies"</span>: {
     <span class="hljs-string">"karma"</span>: <span class="hljs-string">"^0.13.0"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>or by running</p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/0.13/config/browsers.html
+++ b/0.13/config/browsers.html
@@ -126,7 +126,8 @@
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time consuming task,
 so Karma can automate this for you. Simply add the browsers you would like to
 capture into the configuration file:</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -143,13 +144,15 @@ capture into the configuration file:</p>
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -162,7 +165,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can be also configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -174,7 +178,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. E.g. defining</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -183,7 +188,8 @@ user agent. E.g. defining</p>
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>the browser will figure as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -196,17 +202,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID
 parameter to be used to connect to the server. The supplied ID is used
 by the server to keep track of which specific browser is captured.</p>

--- a/0.13/config/configuration-file.html
+++ b/0.13/config/configuration-file.html
@@ -146,13 +146,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -286,7 +288,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>exclude</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -325,7 +328,8 @@ will return exit-code <code>0</code> and display a warning.</p>
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -355,12 +359,14 @@ will return exit-code <code>0</code> and display a warning.</p>
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -370,7 +376,8 @@ will return exit-code <code>0</code> and display a warning.</p>
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>plugins</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[&#39;karma-*&#39;]</code></p>
@@ -425,7 +432,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>

--- a/0.13/config/files.html
+++ b/0.13/config/files.html
@@ -198,26 +198,30 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading Assets</h2>
 <p>By default all assets are served at <code>http://localhost:[PORT]/base/</code></p>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 
         </div>
       </div>

--- a/0.13/config/plugins.html
+++ b/0.13/config/plugins.html
@@ -134,9 +134,11 @@ In fact, all the existing preprocessors, reporters, browser launchers and framew
     <span class="hljs-string">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-string">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads all sibling NPM modules which have a name starting with <code>karma-*</code>.</p>
 <p>You can also explicitly list plugins you want to load via the <code>plugins</code> configuration setting. The configuration value can either be
@@ -149,7 +151,8 @@ a string (module name), which will be required by Karma, or an object (inlined p
   <span class="hljs-comment">// inlined plugins</span>
   {<span class="hljs-string">'framework:xyz'</span>: [<span class="hljs-string">'factory'</span>, factoryFn]},
   <span class="hljs-built_in">require</span>(<span class="hljs-string">'./plugin-required-from-config'</span>)
-]</code></pre>
+]
+</code></pre>
 <p>There are already many <a href="https://npmjs.org/browse/keyword/karma-plugin">existing plugins</a>. Of course, you can write <a href="../dev/plugins.html">your own plugins</a> too!</p>
 
         </div>

--- a/0.13/config/preprocessors.html
+++ b/0.13/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can be also configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Minimatching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>

--- a/0.13/dev/git-commit-msg.html
+++ b/0.13/dev/git-commit-msg.html
@@ -133,7 +133,8 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>First line cannot be longer than 70 characters, second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -174,9 +175,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -186,7 +189,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/0.13/dev/making-changes.html
+++ b/0.13/dev/making-changes.html
@@ -139,14 +139,16 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 $ rm -rf node_modules/karma
 $ <span class="hljs-built_in">cd</span> node_modules
 $ ln -s ../ karma
 $ <span class="hljs-built_in">cd</span> ../
-$ grunt browserify</code></pre>
+$ grunt browserify
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -159,13 +161,16 @@ $ grunt <span class="hljs-built_in">test</span>:e2e
 $ grunt <span class="hljs-built_in">test</span>:client
 
 <span class="hljs-comment"># All tests.</span>
-$ grunt <span class="hljs-built_in">test</span></code></pre>
+$ grunt <span class="hljs-built_in">test</span>
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
-<pre><code class="language-bash">$ npm run lint</code></pre>
+<pre><code class="language-bash">$ npm run lint
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
-<pre><code class="language-bash">$ npm build</code></pre>
+<pre><code class="language-bash">$ npm build
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -173,7 +178,8 @@ $ grunt <span class="hljs-built_in">test</span></code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -183,9 +189,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/0.13/dev/plugins.html
+++ b/0.13/dev/plugins.html
@@ -181,7 +181,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 
         </div>
       </div>

--- a/0.13/dev/public-api.html
+++ b/0.13/dev/public-api.html
@@ -131,18 +131,22 @@ You can, however, call Karma programmatically from your node module. Here is the
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h3><strong>server.start()</strong></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><strong>server.refreshFiles()</strong></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>browser_register</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -198,7 +202,8 @@ You can, however, call Karma programmatically from your node module. Here is the
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>Callback function notes</h2>
 <ul>
 <li>If there is an error, the error code will be provided as the second parameter to the error callback.</li>

--- a/0.13/intro/configuration.html
+++ b/0.13/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change ?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/0.13/intro/installation.html
+++ b/0.13/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/0.13/plus/cloud9.html
+++ b/0.13/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript, and uses NodeJS on the back-end.</p
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/0.13/plus/codio.html
+++ b/0.13/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from right button).</p>

--- a/0.13/plus/emberjs.html
+++ b/0.13/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/0.13/plus/jenkins.html
+++ b/0.13/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -160,7 +161,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/0.13/plus/requirejs.html
+++ b/0.13/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks works just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -268,7 +272,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -295,14 +300,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/0.13/plus/semaphore.html
+++ b/0.13/plus/semaphore.html
@@ -140,19 +140,22 @@ make it easy to run your tests. Here&#39;s an example:</p>
 <span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/.bin/karma start --single-run --browsers PhantomJS'</span>
 }
-<span class="hljs-comment">// ...snip...</span></code></pre>
+<span class="hljs-comment">// ...snip...</span>
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
 <pre><code class="language-javascript"><span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/.bin/karma start --single-run --browsers Firefox'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it in a virtual screen
 during your builds.</p>

--- a/0.13/plus/teamcity.html
+++ b/0.13/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to build configuration: use Command Line runner and fill in <code>Custom script</code> textarea. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> in the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/0.13/plus/travis.html
+++ b/0.13/plus/travis.html
@@ -135,7 +135,8 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root
 create one now. Travis runs <code>npm test</code> to trigger your tests so this
@@ -148,7 +149,8 @@ is where you tell Travis how to run your tests.</p>
 <span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'karma start --single-run --browsers PhantomJS'</span>
 }
-<span class="hljs-comment">// ...snip...</span></code></pre>
+<span class="hljs-comment">// ...snip...</span>
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -161,10 +163,12 @@ like this:</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/0.6/about/versioning.html
+++ b/0.6/about/versioning.html
@@ -118,9 +118,11 @@
         <div id="markdown" class="sixteen columns bottom"><p>Testacular uses <a href="http://semver.org/">Semantic Versioning</a>.</p>
 <p>All even versions (eg. <code>0.2.x</code>, <code>0.4.x</code>) are considered to be stable - no breaking changes or new features, only bug fixes will pushed into this branch.</p>
 <h2>Stable channel (branch <code>stable</code>)</h2>
-<pre><code class="language-bash">$ npm install -g testacular</code></pre>
+<pre><code class="language-bash">$ npm install -g testacular
+</code></pre>
 <h2>Canary channel (branch <code>master</code>)</h2>
-<pre><code class="language-bash">$ npm install -g testacular@canary</code></pre>
+<pre><code class="language-bash">$ npm install -g testacular@canary
+</code></pre>
 
         </div>
       </div>

--- a/0.6/config/browsers.html
+++ b/0.6/config/browsers.html
@@ -118,7 +118,8 @@
         <div id="markdown" class="sixteen columns bottom"><h2>Starting browsers</h2>
 <p>Capturing browsers is kinda boring, so Testacular can do that for you.
 Just simply add into the configuration file:</p>
-<pre><code class="language-javascript">browsers = [<span class="hljs-string">'Chrome'</span>];</code></pre>
+<pre><code class="language-javascript">browsers = [<span class="hljs-string">'Chrome'</span>];
+</code></pre>
 <p>Then, Testacular will take care of autocapturing these browsers, as
 well as killing them.</p>
 <p>Currently available browsers:</p>
@@ -146,17 +147,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the testacular.conf.js</span>
 browsers = [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>];
 
 <span class="hljs-comment">// from cli</span>
-testacular start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+testacular start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, the url with id
 parameter to be used to connect to the server. The supplied id is used
 by the server to determine when the specific browser is captured.</p>

--- a/0.6/config/configuration-file.html
+++ b/0.6/config/configuration-file.html
@@ -211,7 +211,8 @@ it again. After three attempts to capture it, Testacular will give up.</p>
 <pre><code class="language-javascript">proxies =  {
   <span class="hljs-string">'/static'</span>: <span class="hljs-string">'http://gstatic.com'</span>,
   <span class="hljs-string">'/web'</span>: <span class="hljs-string">'http://localhost:9000'</span>
-};</code></pre>
+};
+</code></pre>
 <h2>reportSlowerThan</h2>
 <p><strong>Type:</strong> Number</p>
 <p><strong>Default:</strong> <code>0</code></p>

--- a/0.6/config/coverage.html
+++ b/0.6/config/coverage.html
@@ -128,7 +128,8 @@ For example if all your code lives in <code>lib/</code> you need to add this to 
 configuration file.</p>
 <pre><code class="language-javascript">preprocessors = {
   <span class="hljs-string">'**/lib/*.js'</span>: <span class="hljs-string">'coverage'</span>
-};</code></pre>
+};
+</code></pre>
 <p>You should not however include the files that aren&#39;t directly related to your
 program, e.g. libraries, mocks, neither tests.</p>
 <p>This is a <strong>BAD</strong> example</p>
@@ -140,7 +141,8 @@ program, e.g. libraries, mocks, neither tests.</p>
 ];
 preprocessors = {
   <span class="hljs-string">'**/*.js'</span>: <span class="hljs-string">'coverage'</span>
-};</code></pre>
+};
+</code></pre>
 <p>In this example also JASMINE and JASMINE_ADAPTER get included but they shouldn&#39;t as
 these file are only for the test setup used and not for your program.</p>
 <p>If you include these files there can occur side effects like the following,</p>
@@ -150,7 +152,8 @@ these file are only for the test setup used and not for your program.</p>
 </ul>
 <h2>Reporter</h2>
 <p>To activate the coverage reporter add this to your configuration file.</p>
-<pre><code class="language-javascript">reporters = [<span class="hljs-string">'coverage'</span>];</code></pre>
+<pre><code class="language-javascript">reporters = [<span class="hljs-string">'coverage'</span>];
+</code></pre>
 <p>This will create a coverage report for every browser that the tests are run in.
 In addition, it will create a JSON file that outputs the intermediate data.</p>
 <h2>Reporter Options</h2>
@@ -158,7 +161,8 @@ In addition, it will create a JSON file that outputs the intermediate data.</p>
 <pre><code class="language-javascript">coverageReporter = {
   <span class="hljs-attr">type</span> : <span class="hljs-string">'html'</span>,
   <span class="hljs-attr">dir</span> : <span class="hljs-string">'coverage/'</span>
-}</code></pre>
+}
+</code></pre>
 <p>If you want to configure it yourself here are the options explained.</p>
 <h3>type</h3>
 <p><strong>Type:</strong> String</p>
@@ -176,7 +180,8 @@ In addition, it will create a JSON file that outputs the intermediate data.</p>
   <span class="hljs-attr">type</span> : <span class="hljs-string">'text'</span>,
   <span class="hljs-attr">dir</span> : <span class="hljs-string">'coverage/'</span>,
   <span class="hljs-attr">file</span> : <span class="hljs-string">'coverage.txt'</span>
-}</code></pre>
+}
+</code></pre>
 <p>If no filename is given, it will write the output to the console.</p>
 <h3>dir</h3>
 <p><strong>Type:</strong> String</p>

--- a/0.6/config/files.html
+++ b/0.6/config/files.html
@@ -132,7 +132,8 @@ to use Mocha you have the following in your config file:</p>
 <pre><code class="language-javascript">files = [
   MOCHA,
   MOCHA_ADAPTER
-];</code></pre>
+];
+</code></pre>
 <h2>Pattern matching and <code>basePath</code></h2>
 <ul>
 <li>All the relative patterns will get resolved to <code>basePath</code> first.</li>
@@ -154,7 +155,8 @@ same file, it&#39;s included as if it only matched the first pattern.</li>
 more closely.</p>
 <p>If you define them like before a simple pattern like
 <code>&#39;test/unit/*.js&#39;</code> this gets expanded internally to the following:</p>
-<pre><code class="language-javascript">  {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/unit/*.js'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>}</code></pre>
+<pre><code class="language-javascript">  {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/unit/*.js'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>}
+</code></pre>
 <h3><code>pattern</code></h3>
 <ul>
 <li><strong>Description.</strong> The pattern to use for matching.</li>
@@ -197,7 +199,8 @@ watched for changes.</li>
 
   <span class="hljs-comment">// this file only gets watched but otherwise ignored</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'app/index.html'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">false</span>}
-];</code></pre>
+];
+</code></pre>
 
         </div>
       </div>

--- a/0.6/config/preprocessors.html
+++ b/0.6/config/preprocessors.html
@@ -121,7 +121,8 @@ in the config file.</p>
 <pre><code class="language-javascript">preprocessors = {
   <span class="hljs-string">'**/*.coffee'</span>: <span class="hljs-string">'coffee'</span>,
   <span class="hljs-string">'**/*.html'</span>: <span class="hljs-string">'html2js'</span>
-};</code></pre>
+};
+</code></pre>
 <h2>Available Preprocessors</h2>
 <ul>
 <li><a href="https://github.com/testacular/testacular/blob/v0.5.8/lib/preprocessors/Coffee.js">coffee</a></li>

--- a/0.6/dev/contributing.html
+++ b/0.6/dev/contributing.html
@@ -133,10 +133,12 @@ already exist.<ul>
 <li><p>Clone your fork</p>
 </li>
 <li><p>Install dependencies via</p>
-<pre><code class="language-bash">$ npm install</code></pre>
+<pre><code class="language-bash">$ npm install
+</code></pre>
 </li>
 <li><p>Install global dependencies via</p>
-<pre><code class="language-bash">$ npm install grunt-cli -g</code></pre>
+<pre><code class="language-bash">$ npm install grunt-cli -g
+</code></pre>
 </li>
 <li><p>Checkout a new branch (usually based on <code>master</code>) and name it accordingly to what
 you intend to do</p>
@@ -154,11 +156,14 @@ $ grunt <span class="hljs-built_in">test</span>
 
 $ grunt <span class="hljs-built_in">test</span>:unit
 $ grunt <span class="hljs-built_in">test</span>:e2e
-$ grunt <span class="hljs-built_in">test</span>:client</code></pre>
+$ grunt <span class="hljs-built_in">test</span>:client
+</code></pre>
 <p>Lint the files via</p>
-<pre><code class="language-bash">$ grunt lint</code></pre>
+<pre><code class="language-bash">$ grunt lint
+</code></pre>
 <p>Build the project via</p>
-<pre><code class="language-bash">$ grunt build</code></pre>
+<pre><code class="language-bash">$ grunt build
+</code></pre>
 <p>The default task, just calling <code>grunt</code> will run <code>build lint test</code>.</p>
 <p>If grunt fails, make sure grunt-0.4x is installed: <a href="https://github.com/gruntjs/grunt/wiki/Getting-started">https://github.com/gruntjs/grunt/wiki/Getting-started</a>.</p>
 <h2>Submitting Changes</h2>

--- a/0.6/dev/git-commit-msg.html
+++ b/0.6/dev/git-commit-msg.html
@@ -120,7 +120,8 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>First line cannot be longer than 70 characters, second line is always
 blank and other lines should be wrapped at 80 characters.</p>
@@ -162,9 +163,11 @@ omitted.</p>
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -174,7 +177,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>.</p>
 

--- a/0.6/dev/public-api.html
+++ b/0.6/dev/public-api.html
@@ -125,7 +125,8 @@ using Testacular with <a href="http://gruntjs.com/">Grunt</a> for instance.</p>
 server.start({<span class="hljs-attr">port</span>: <span class="hljs-number">9877</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Testacular has exitted with '</span> + exitCode);
   process.exit(exitCode);
-});</code></pre>
+});
+</code></pre>
 <h2>testacular.runner</h2>
 <h3><strong>runner.run(options, [callback=process.exit])</strong></h3>
 <p>Equivalent of <code>testacular run</code>.</p>
@@ -133,7 +134,8 @@ server.start({<span class="hljs-attr">port</span>: <span class="hljs-number">987
 runner.run({<span class="hljs-attr">runnerPort</span>: <span class="hljs-number">9100</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Testacular has exitted with '</span> + exitCode);
   process.exit(exitCode);
-});</code></pre>
+});
+</code></pre>
 
         </div>
       </div>

--- a/0.6/intro/configuration.html
+++ b/0.6/intro/configuration.html
@@ -124,12 +124,14 @@ which contains most of the options.</p>
 <p>A third way is to use <code>testacular init</code> to generate it.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># This will ask you a few questions and generate a new config file</span>
 <span class="hljs-comment"># called my.conf.js</span>
-$ testacular init my.conf.js</code></pre>
+$ testacular init my.conf.js
+</code></pre>
 <h2>Starting Testacular</h2>
 <p>When starting testacular, you can pass a path to the configuration file as an argument.</p>
 <p>By default, Testacular will look for <code>testacular.conf.js</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Testacular using your configuration</span>
-$ testacular start my.conf.js</code></pre>
+$ testacular start my.conf.js
+</code></pre>
 <p>For more info about configuration file, see the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some of the configurations can be specified as a command line argument, which

--- a/0.6/intro/installation.html
+++ b/0.6/intro/installation.html
@@ -125,7 +125,8 @@ global <code>node_modules</code> directory and create a symlink to its binary.</
 <pre><code class="language-bash">$ npm install -g testacular
 
 <span class="hljs-comment"># Start Testacular</span>
-$ testacular start</code></pre>
+$ testacular start
+</code></pre>
 <h2>Local Installation</h2>
 <p>A local installation will install Testacular into your current
 directory&#39;s <code>node_modules</code>. That allows you to have different
@@ -133,7 +134,8 @@ versions for different projects.</p>
 <pre><code class="language-bash">$ npm install testacular
 
 <span class="hljs-comment"># Start Testacular</span>
-$ ./node_modules/.bin/testacular start</code></pre>
+$ ./node_modules/.bin/testacular start
+</code></pre>
 
         </div>
       </div>

--- a/0.6/intro/troubleshooting.html
+++ b/0.6/intro/troubleshooting.html
@@ -129,7 +129,8 @@ have to figure them out again and again.</p>
 <ul>
 <li><p>Chrome won&#39;t start. (Issues: <a href="https://github.com/testacular/testacular/issues/202">#202</a>, <a href="https://github.com/testacular/testacular/issues/74">#74</a>)</p>
 <ol>
-<li>Set <code>CHROME_BIN</code> like this<pre><code>&gt; export CHROME_BIN='C:<span class="hljs-tag">\<span class="hljs-name">Program</span></span> Files (x86)<span class="hljs-tag">\<span class="hljs-name">Google</span></span><span class="hljs-tag">\<span class="hljs-name">Chrome</span></span><span class="hljs-tag">\<span class="hljs-name">Application</span></span><span class="hljs-tag">\<span class="hljs-name">chrome</span></span>.exe'</code></pre>
+<li>Set <code>CHROME_BIN</code> like this<pre><code>&gt; export CHROME_BIN='C:<span class="hljs-tag">\<span class="hljs-name">Program</span></span> Files (x86)<span class="hljs-tag">\<span class="hljs-name">Google</span></span><span class="hljs-tag">\<span class="hljs-name">Chrome</span></span><span class="hljs-tag">\<span class="hljs-name">Application</span></span><span class="hljs-tag">\<span class="hljs-name">chrome</span></span>.exe'
+</code></pre>
 </li>
 <li>Increase the timeout from 5000ms to 10000ms. At 5000ms, timeouts
 occurred and the retry logic kicks in and eventually resolves

--- a/0.6/plus/Cloud9.html
+++ b/0.6/plus/Cloud9.html
@@ -127,7 +127,8 @@
 <pre><code class="language-javascript">browsers = [<span class="hljs-string">'PhantomJS'</span>];
 hostname = process.env.IP;
 port = process.env.PORT;
-runnerPort = <span class="hljs-number">0</span>;</code></pre>
+runnerPort = <span class="hljs-number">0</span>;
+</code></pre>
 
         </div>
       </div>

--- a/0.6/plus/Jenkins-CI.html
+++ b/0.6/plus/Jenkins-CI.html
@@ -140,7 +140,8 @@ distributions and user permissions.</p>
 reporters = [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>];
 junitReporter = {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-};</code></pre>
+};
+</code></pre>
 <p>Please note the <code>test-result.xml</code> file will be output to the present
 working directory (and you will need to tell Jenkins where to find it).</p>
 <h2>Create a new Jenkins Job</h2>
@@ -153,7 +154,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process” checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/0.6/plus/RequireJS.html
+++ b/0.6/plus/RequireJS.html
@@ -130,12 +130,14 @@ directory structure upon which these are based looks like this:</p>
   <span class="hljs-built_in">test</span>/
     MyModule.test.js
     <span class="hljs-built_in">test</span>-main.js
-testacular.conf.js</code></pre>
+testacular.conf.js
+</code></pre>
 <h3>Initialize Testacular</h3>
 <p>Testacular comes with a nice utility for generating a config file
 (default name: <code>testacular.conf.js</code>) that it needs in order to run.</p>
 <p>In your terminal, type:</p>
-<pre><code class="language-bash">$ testacular init</code></pre>
+<pre><code class="language-bash">$ testacular init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to
 source and tests and which browsers to capture.</p>
 <h3>RequireJs Shim</h3>
@@ -175,7 +177,8 @@ should be the last file listed.</p>
 
   <span class="hljs-comment">// test main require module last</span>
   <span class="hljs-string">'test/test-main.js'</span>
-];</code></pre>
+];
+</code></pre>
 <p>This config is awesome. It replaces an html test runner that you would otherwise have to build.</p>
 <h2>RequireJs Main Module</h2>
 <p>Just like any RequireJs project, you need a main module to bootstrap
@@ -216,7 +219,8 @@ it starts the tests.</p>
   <span class="hljs-attr">deps</span>: tests,
   <span class="hljs-comment">// start test run, once requirejs is done</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__testacular__.start
-});</code></pre>
+});
+</code></pre>
 <h2>RequireJs Test in Testacular</h2>
 <p>All the setup thus far has been in preparation for the code to follow.
 The test can now be setup as a RequireJs module. It can require the
@@ -226,7 +230,8 @@ is a Testacular adapter for).</p>
 assertions. Note that by using RequireJs and running in the browser,
 we can’t just <code>require(&#39;chai&#39;)</code>. It has to be required using the
 asynchronous callback to avoid this error:</p>
-<pre><code class="language-bash">Uncaught Error: Module name “../node_modules/chai/chai” has not been loaded yet <span class="hljs-keyword">for</span> context: _. Use require([])</code></pre>
+<pre><code class="language-bash">Uncaught Error: Module name “../node_modules/chai/chai” has not been loaded yet <span class="hljs-keyword">for</span> context: _. Use require([])
+</code></pre>
 <p>And finally, <code>should()</code> must be invoked to be available in the test.</p>
 <p>So, a simple test will look like:</p>
 <pre><code class="language-javascript">define([<span class="hljs-string">'../node_modules/chai/chai'</span>, <span class="hljs-string">'MyModule'</span>], <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">chai, MyModule</span>) </span>{
@@ -241,12 +246,15 @@ asynchronous callback to avoid this error:</p>
       });
     });
   });
-});</code></pre>
+});
+</code></pre>
 <h2>Run the Tests in Testacular</h2>
 <p>To start the Testacular server:</p>
-<pre><code class="language-bash">$ testacular start</code></pre>
+<pre><code class="language-bash">$ testacular start
+</code></pre>
 <p>If you didn&#39;t configure to watch all the files and run tests automatically on any change, you can trigger the tests manually. Just type:</p>
-<pre><code class="language-bash">$ testacular run</code></pre>
+<pre><code class="language-bash">$ testacular run
+</code></pre>
 
         </div>
       </div>

--- a/0.6/plus/Travis-CI.html
+++ b/0.6/plus/Travis-CI.html
@@ -127,7 +127,8 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-number">0</span>.<span class="hljs-number">8</span></code></pre>
+  - <span class="hljs-number">0</span>.<span class="hljs-number">8</span>
+</code></pre>
 <h2>Setup a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root
 create one now. Travis runs <code>npm test</code> to trigger your tests so this
@@ -140,7 +141,8 @@ is where you tell Travis how to run your tests.</p>
 <span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/.bin/testacular start --single-run --browsers PhantomJS'</span>
 }
-<span class="hljs-comment">// ...snip...</span></code></pre>
+<span class="hljs-comment">// ...snip...</span>
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Testacular.</p>
@@ -153,10 +155,12 @@ like this:</p>
   - <span class="hljs-number">0</span>.<span class="hljs-number">8</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">./node_modules/.bin/testacular start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">./node_modules/.bin/testacular start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/0.8/about/versioning.html
+++ b/0.8/about/versioning.html
@@ -119,9 +119,11 @@
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org/">Semantic Versioning</a>.</p>
 <p>All even versions (eg. <code>0.2.x</code>, <code>0.4.x</code>) are considered to be stable - no breaking changes or new features, only bug fixes will pushed into this branch.</p>
 <h2>Stable channel (branch <code>stable</code>)</h2>
-<pre><code class="language-bash">$ npm install -g karma</code></pre>
+<pre><code class="language-bash">$ npm install -g karma
+</code></pre>
 <h2>Canary channel (branch <code>master</code>)</h2>
-<pre><code class="language-bash">$ npm install -g karma@canary</code></pre>
+<pre><code class="language-bash">$ npm install -g karma@canary
+</code></pre>
 
         </div>
       </div>

--- a/0.8/config/browsers.html
+++ b/0.8/config/browsers.html
@@ -119,7 +119,8 @@
         <div id="markdown" class="sixteen columns bottom"><h2>Starting browsers</h2>
 <p>Capturing browsers is kinda boring, so Karma can do that for you.
 Just simply add into the configuration file:</p>
-<pre><code class="language-javascript">browsers = [<span class="hljs-string">'Chrome'</span>];</code></pre>
+<pre><code class="language-javascript">browsers = [<span class="hljs-string">'Chrome'</span>];
+</code></pre>
 <p>Then, Karma will take care of autocapturing these browsers, as
 well as killing them.</p>
 <p>Currently available browsers:</p>
@@ -147,17 +148,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 browsers = [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>];
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, the url with id
 parameter to be used to connect to the server. The supplied id is used
 by the server to determine when the specific browser is captured.</p>

--- a/0.8/config/configuration-file.html
+++ b/0.8/config/configuration-file.html
@@ -212,7 +212,8 @@ it again. After three attempts to capture it, Karma will give up.</p>
 <pre><code class="language-javascript">proxies =  {
   <span class="hljs-string">'/static'</span>: <span class="hljs-string">'http://gstatic.com'</span>,
   <span class="hljs-string">'/web'</span>: <span class="hljs-string">'http://localhost:9000'</span>
-};</code></pre>
+};
+</code></pre>
 <h2>reportSlowerThan</h2>
 <p><strong>Type:</strong> Number</p>
 <p><strong>Default:</strong> <code>0</code></p>

--- a/0.8/config/coverage.html
+++ b/0.8/config/coverage.html
@@ -129,7 +129,8 @@ For example if all your code lives in <code>lib/</code> you need to add this to 
 configuration file.</p>
 <pre><code class="language-javascript">preprocessors = {
   <span class="hljs-string">'**/lib/*.js'</span>: <span class="hljs-string">'coverage'</span>
-};</code></pre>
+};
+</code></pre>
 <p>You should not however include the files that aren&#39;t directly related to your
 program, e.g. libraries, mocks, neither tests.</p>
 <p>This is a <strong>BAD</strong> example</p>
@@ -141,7 +142,8 @@ program, e.g. libraries, mocks, neither tests.</p>
 ];
 preprocessors = {
   <span class="hljs-string">'**/*.js'</span>: <span class="hljs-string">'coverage'</span>
-};</code></pre>
+};
+</code></pre>
 <p>In this example also JASMINE and JASMINE_ADAPTER get included but they shouldn&#39;t as
 these file are only for the test setup used and not for your program.</p>
 <p>If you include these files there can occur side effects like the following,</p>
@@ -151,7 +153,8 @@ these file are only for the test setup used and not for your program.</p>
 </ul>
 <h2>Reporter</h2>
 <p>To activate the coverage reporter add this to your configuration file.</p>
-<pre><code class="language-javascript">reporters = [<span class="hljs-string">'coverage'</span>];</code></pre>
+<pre><code class="language-javascript">reporters = [<span class="hljs-string">'coverage'</span>];
+</code></pre>
 <p>This will create a coverage report for every browser that the tests are run in.
 In addition, it will create a JSON file that outputs the intermediate data.</p>
 <h2>Reporter Options</h2>
@@ -159,7 +162,8 @@ In addition, it will create a JSON file that outputs the intermediate data.</p>
 <pre><code class="language-javascript">coverageReporter = {
   <span class="hljs-attr">type</span> : <span class="hljs-string">'html'</span>,
   <span class="hljs-attr">dir</span> : <span class="hljs-string">'coverage/'</span>
-}</code></pre>
+}
+</code></pre>
 <p>If you want to configure it yourself here are the options explained.</p>
 <h3>type</h3>
 <p><strong>Type:</strong> String</p>
@@ -177,7 +181,8 @@ In addition, it will create a JSON file that outputs the intermediate data.</p>
   <span class="hljs-attr">type</span> : <span class="hljs-string">'text'</span>,
   <span class="hljs-attr">dir</span> : <span class="hljs-string">'coverage/'</span>,
   <span class="hljs-attr">file</span> : <span class="hljs-string">'coverage.txt'</span>
-}</code></pre>
+}
+</code></pre>
 <p>If no filename is given, it will write the output to the console.</p>
 <h3>dir</h3>
 <p><strong>Type:</strong> String</p>

--- a/0.8/config/files.html
+++ b/0.8/config/files.html
@@ -133,7 +133,8 @@ to use Mocha you have the following in your config file:</p>
 <pre><code class="language-javascript">files = [
   MOCHA,
   MOCHA_ADAPTER
-];</code></pre>
+];
+</code></pre>
 <h2>Pattern matching and <code>basePath</code></h2>
 <ul>
 <li>All the relative patterns will get resolved to <code>basePath</code> first.</li>
@@ -155,7 +156,8 @@ same file, it&#39;s included as if it only matched the first pattern.</li>
 more closely.</p>
 <p>If you define them like before a simple pattern like
 <code>&#39;test/unit/*.js&#39;</code> this gets expanded internally to the following:</p>
-<pre><code class="language-javascript">  {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/unit/*.js'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>}</code></pre>
+<pre><code class="language-javascript">  {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/unit/*.js'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>}
+</code></pre>
 <h3><code>pattern</code></h3>
 <ul>
 <li><strong>Description.</strong> The pattern to use for matching.</li>
@@ -198,7 +200,8 @@ watched for changes.</li>
 
   <span class="hljs-comment">// this file only gets watched but otherwise ignored</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'app/index.html'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">false</span>}
-];</code></pre>
+];
+</code></pre>
 
         </div>
       </div>

--- a/0.8/config/preprocessors.html
+++ b/0.8/config/preprocessors.html
@@ -122,7 +122,8 @@ in the config file.</p>
 <pre><code class="language-javascript">preprocessors = {
   <span class="hljs-string">'**/*.coffee'</span>: <span class="hljs-string">'coffee'</span>,
   <span class="hljs-string">'**/*.html'</span>: <span class="hljs-string">'html2js'</span>
-};</code></pre>
+};
+</code></pre>
 <h2>Available Preprocessors</h2>
 <ul>
 <li><a href="https://github.com/karma-runner/karma/blob/v0.5.8/lib/preprocessors/Coffee.js">coffee</a></li>

--- a/0.8/dev/contributing.html
+++ b/0.8/dev/contributing.html
@@ -134,10 +134,12 @@ already exist.<ul>
 <li><p>Clone your fork</p>
 </li>
 <li><p>Install dependencies via</p>
-<pre><code class="language-bash">$ npm install</code></pre>
+<pre><code class="language-bash">$ npm install
+</code></pre>
 </li>
 <li><p>Install global dependencies via</p>
-<pre><code class="language-bash">$ npm install grunt-cli -g</code></pre>
+<pre><code class="language-bash">$ npm install grunt-cli -g
+</code></pre>
 </li>
 <li><p>Checkout a new branch (usually based on <code>master</code>) and name it accordingly to what
 you intend to do</p>
@@ -155,11 +157,14 @@ $ grunt <span class="hljs-built_in">test</span>
 
 $ grunt <span class="hljs-built_in">test</span>:unit
 $ grunt <span class="hljs-built_in">test</span>:e2e
-$ grunt <span class="hljs-built_in">test</span>:client</code></pre>
+$ grunt <span class="hljs-built_in">test</span>:client
+</code></pre>
 <p>Lint the files via</p>
-<pre><code class="language-bash">$ grunt lint</code></pre>
+<pre><code class="language-bash">$ grunt lint
+</code></pre>
 <p>Build the project via</p>
-<pre><code class="language-bash">$ grunt build</code></pre>
+<pre><code class="language-bash">$ grunt build
+</code></pre>
 <p>The default task, just calling <code>grunt</code> will run <code>build lint test</code>.</p>
 <p>If grunt fails, make sure grunt-0.4x is installed: <a href="https://github.com/gruntjs/grunt/wiki/Getting-started">https://github.com/gruntjs/grunt/wiki/Getting-started</a>.</p>
 <h2>Submitting Changes</h2>

--- a/0.8/dev/git-commit-msg.html
+++ b/0.8/dev/git-commit-msg.html
@@ -121,7 +121,8 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>First line cannot be longer than 70 characters, second line is always
 blank and other lines should be wrapped at 80 characters.</p>
@@ -163,9 +164,11 @@ omitted.</p>
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -175,7 +178,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>.</p>
 

--- a/0.8/dev/public-api.html
+++ b/0.8/dev/public-api.html
@@ -126,7 +126,8 @@ using Karma with <a href="http://gruntjs.com/">Grunt</a> for instance.</p>
 server.start({<span class="hljs-attr">port</span>: <span class="hljs-number">9877</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode);
   process.exit(exitCode);
-});</code></pre>
+});
+</code></pre>
 <h2>karma.runner</h2>
 <h3><strong>runner.run(options, [callback=process.exit])</strong></h3>
 <p>Equivalent of <code>karma run</code>.</p>
@@ -134,7 +135,8 @@ server.start({<span class="hljs-attr">port</span>: <span class="hljs-number">987
 runner.run({<span class="hljs-attr">runnerPort</span>: <span class="hljs-number">9100</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode);
   process.exit(exitCode);
-});</code></pre>
+});
+</code></pre>
 
         </div>
       </div>

--- a/0.8/intro/configuration.html
+++ b/0.8/intro/configuration.html
@@ -125,12 +125,14 @@ which contains most of the options.</p>
 <p>A third way is to use <code>karma init</code> to generate it.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># This will ask you a few questions and generate a new config file</span>
 <span class="hljs-comment"># called my.conf.js</span>
-$ karma init my.conf.js</code></pre>
+$ karma init my.conf.js
+</code></pre>
 <h2>Starting Karma</h2>
 <p>When starting Karma, you can pass a path to the configuration file as an argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more info about configuration file, see the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some of the configurations can be specified as a command line argument, which

--- a/0.8/intro/installation.html
+++ b/0.8/intro/installation.html
@@ -126,7 +126,8 @@ global <code>node_modules</code> directory and create a symlink to its binary.</
 <pre><code class="language-bash">$ npm install -g karma
 
 <span class="hljs-comment"># Start Karma</span>
-$ karma start</code></pre>
+$ karma start
+</code></pre>
 <h2>Local Installation</h2>
 <p>A local installation will install Karma into your current
 directory&#39;s <code>node_modules</code>. That allows you to have different
@@ -134,7 +135,8 @@ versions for different projects.</p>
 <pre><code class="language-bash">$ npm install karma
 
 <span class="hljs-comment"># Start Karma</span>
-$ ./node_modules/.bin/karma start</code></pre>
+$ ./node_modules/.bin/karma start
+</code></pre>
 
         </div>
       </div>

--- a/0.8/intro/troubleshooting.html
+++ b/0.8/intro/troubleshooting.html
@@ -130,7 +130,8 @@ have to figure them out again and again.</p>
 <ul>
 <li><p>Chrome won&#39;t start. (Issues: <a href="https://github.com/karma-runner/karma/issues/202">#202</a>, <a href="https://github.com/karma-runner/karma/issues/74">#74</a>)</p>
 <ol>
-<li>Set <code>CHROME_BIN</code> like this<pre><code>&gt; export CHROME_BIN='C:<span class="hljs-tag">\<span class="hljs-name">Program</span></span> Files (x86)<span class="hljs-tag">\<span class="hljs-name">Google</span></span><span class="hljs-tag">\<span class="hljs-name">Chrome</span></span><span class="hljs-tag">\<span class="hljs-name">Application</span></span><span class="hljs-tag">\<span class="hljs-name">chrome</span></span>.exe'</code></pre>
+<li>Set <code>CHROME_BIN</code> like this<pre><code>&gt; export CHROME_BIN='C:<span class="hljs-tag">\<span class="hljs-name">Program</span></span> Files (x86)<span class="hljs-tag">\<span class="hljs-name">Google</span></span><span class="hljs-tag">\<span class="hljs-name">Chrome</span></span><span class="hljs-tag">\<span class="hljs-name">Application</span></span><span class="hljs-tag">\<span class="hljs-name">chrome</span></span>.exe'
+</code></pre>
 </li>
 <li>Increase the timeout from 5000ms to 10000ms. At 5000ms, timeouts
 occurred and the retry logic kicks in and eventually resolves

--- a/0.8/plus/Cloud9.html
+++ b/0.8/plus/Cloud9.html
@@ -128,7 +128,8 @@
 <pre><code class="language-javascript">browsers = [<span class="hljs-string">'PhantomJS'</span>];
 hostname = process.env.IP;
 port = process.env.PORT;
-runnerPort = <span class="hljs-number">0</span>;</code></pre>
+runnerPort = <span class="hljs-number">0</span>;
+</code></pre>
 
         </div>
       </div>

--- a/0.8/plus/Jenkins-CI.html
+++ b/0.8/plus/Jenkins-CI.html
@@ -141,7 +141,8 @@ distributions and user permissions.</p>
 reporters = [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>];
 junitReporter = {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-};</code></pre>
+};
+</code></pre>
 <p>Please note the <code>test-result.xml</code> file will be output to the present
 working directory (and you will need to tell Jenkins where to find it).</p>
 <h2>Create a new Jenkins Job</h2>
@@ -154,7 +155,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process” checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/0.8/plus/RequireJS.html
+++ b/0.8/plus/RequireJS.html
@@ -138,11 +138,13 @@ this:</p>
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to
 source and test and which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks works just
@@ -180,7 +182,8 @@ files = [
 <span class="hljs-comment">// list of files to exclude</span>
 exclude = [
     <span class="hljs-string">'src/main.js'</span>
-];</code></pre>
+];
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this is <code>test/test-main.js</code>.</p>
@@ -231,7 +234,8 @@ requirejs.config({
 
     <span class="hljs-comment">// start test run, once Require.js is done</span>
     <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -256,14 +260,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/0.8/plus/Semaphore-CI.html
+++ b/0.8/plus/Semaphore-CI.html
@@ -133,19 +133,22 @@ make it easy to run your tests. Here&#39;s an example:</p>
 <span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/.bin/karma start --single-run --browsers PhantomJS'</span>
 }
-<span class="hljs-comment">// ...snip...</span></code></pre>
+<span class="hljs-comment">// ...snip...</span>
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
 <pre><code class="language-javascript"><span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/.bin/karma start --single-run --browsers Firefox'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the screencast on the Semaphore homepage.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it in a virtual screen
 during your builds.</p>

--- a/0.8/plus/Travis-CI.html
+++ b/0.8/plus/Travis-CI.html
@@ -128,7 +128,8 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-number">0</span>.<span class="hljs-number">8</span></code></pre>
+  - <span class="hljs-number">0</span>.<span class="hljs-number">8</span>
+</code></pre>
 <h2>Setup a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root
 create one now. Travis runs <code>npm test</code> to trigger your tests so this
@@ -141,7 +142,8 @@ is where you tell Travis how to run your tests.</p>
 <span class="hljs-string">'scripts'</span>: {
    <span class="hljs-string">'test'</span>: <span class="hljs-string">'./node_modules/.bin/karma start --single-run --browsers PhantomJS'</span>
 }
-<span class="hljs-comment">// ...snip...</span></code></pre>
+<span class="hljs-comment">// ...snip...</span>
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -154,10 +156,12 @@ like this:</p>
   - <span class="hljs-number">0</span>.<span class="hljs-number">8</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">./node_modules/.bin/karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">./node_modules/.bin/karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/1.0/about/changelog.html
+++ b/1.0/about/changelog.html
@@ -547,11 +547,13 @@ to match this new format.</p>
 <ul>
 <li><p>The public api interface has changed to a constructor form. To upgrade change</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 <p>to</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 <p>Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</p>
 </li>
@@ -1181,7 +1183,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1226,7 +1229,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/1.0/about/migration.html
+++ b/1.0/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/1.0/about/versioning.html
+++ b/1.0/about/versioning.html
@@ -125,9 +125,11 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org">Semantic Versioning</a>.</p>
 <p>It is recommended that you add Karma by running:</p>
-<pre><code class="language-bash">$ yarn add --dev karma</code></pre>
+<pre><code class="language-bash">$ yarn add --dev karma
+</code></pre>
 <p>or: </p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/1.0/config/browsers.html
+++ b/1.0/config/browsers.html
@@ -124,7 +124,8 @@
       </div>
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time-consuming task. However, Karma can automate this for you. Simply add the browsers you would like to capture into the <a href="configuration-file.html">configuration file</a>.</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them after the job is over.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -142,13 +143,15 @@
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then, inside your configuration file, add the browser name in <code>browsers</code> array.</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also, keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -161,7 +164,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can also be configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -173,7 +177,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. Here is a code snippet example explaining how to set a display name for a custom launcher.</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -182,7 +187,8 @@ user agent. Here is a code snippet example explaining how to set a display name 
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>If the definition is as above, the browser will be displayed as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -195,17 +201,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID-parameter to be used to connect to the server. The supplied ID is used by the server to keep track of which specific browser is captured.</p>
 
         </div>

--- a/1.0/config/configuration-file.html
+++ b/1.0/config/configuration-file.html
@@ -148,13 +148,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <pre><code class="language-typescript"><span class="hljs-comment">// karma.conf.ts</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
   config.set({
@@ -162,7 +164,8 @@ which accepts one argument: the configuration object.</p>
     frameworks: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-}</code></pre>
+}
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -215,7 +218,8 @@ properties, all of which are optional:</p>
   <span class="hljs-attr">format</span>: string,
   <span class="hljs-attr">path</span>:   string,
   <span class="hljs-attr">terminal</span>: boolean
-}</code></pre>
+}
+</code></pre>
 <p>Here the <code>level</code> is the desired log-level, where level <code>log</code> always is logged. The format
 is a string where <code>%b</code>, <code>%t</code>, <code>%T</code>, and <code>%m</code> are replaced with the browser string,
 log type in lower-case, log type in uppercase, and log message, respectively. This format will
@@ -334,7 +338,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>detached</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>false</code></p>
@@ -383,7 +388,8 @@ will return exit-code <code>0</code> and display a warning.</p>
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -413,12 +419,14 @@ will return exit-code <code>0</code> and display a warning.</p>
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -428,7 +436,8 @@ will return exit-code <code>0</code> and display a warning.</p>
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>beforeMiddleware</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -498,7 +507,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>
@@ -563,7 +573,8 @@ between browsers and the testing server).</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-javascript">proxyReq: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">proxyReq, req, res, options</span>) </span>{
   proxyReq.setHeader(<span class="hljs-string">'Referer'</span>, <span class="hljs-string">'https://www.example.com/'</span>);
-}</code></pre>
+}
+</code></pre>
 <h2>proxyRes</h2>
 <p><strong>Type:</strong> Function</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -576,7 +587,8 @@ between browsers and the testing server).</p>
       <span class="hljs-keyword">return</span> cookie.replace(<span class="hljs-regexp">/\s*secure;?/i</span>, <span class="hljs-string">''</span>);
     })
   }
-}</code></pre>
+}
+</code></pre>
 <h2>upstreamProxy</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>undefined</code></p>

--- a/1.0/config/files.html
+++ b/1.0/config/files.html
@@ -203,26 +203,30 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading Assets</h2>
 <p>By default all assets are served at <code>http://localhost:[PORT]/base/</code></p>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However, they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition, you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <h2>Webserver features</h2>
 <ul>
 <li><a href="https://en.wikipedia.org/wiki/Byte_serving">Range requests</a>.</li>

--- a/1.0/config/plugins.html
+++ b/1.0/config/plugins.html
@@ -134,9 +134,11 @@ In fact, all the existing preprocessors, reporters, browser launchers and framew
     <span class="hljs-string">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-string">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads all sibling NPM modules which have a name starting with <code>karma-*</code>.</p>
 <p>You can also explicitly list plugins you want to load via the <code>plugins</code> configuration setting. The configuration value can either be
@@ -149,7 +151,8 @@ a string (module name), which will be required by Karma, or an object (inlined p
   <span class="hljs-comment">// inlined plugins</span>
   {<span class="hljs-string">'framework:xyz'</span>: [<span class="hljs-string">'factory'</span>, factoryFn]},
   <span class="hljs-built_in">require</span>(<span class="hljs-string">'./plugin-required-from-config'</span>)
-]</code></pre>
+]
+</code></pre>
 <p>There are already many <a href="https://npmjs.org/browse/keyword/karma-plugin">existing plugins</a>. Of course, you can write <a href="../dev/plugins.html">your own plugins</a> too!</p>
 
         </div>

--- a/1.0/config/preprocessors.html
+++ b/1.0/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can also be configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Mini matching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>
@@ -190,25 +195,29 @@ will execute the preprocessors over that file in the order they are listed in
 the corresponding array. So for instance, if the config object is:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then karma will execute <code>&#39;a&#39;</code> before executing <code>&#39;b&#39;</code>.</p>
 <p>If a file matches multiple keys, karma will do its best to execute the
 preprocessors in a reasonable order.  So if you have:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then for <code>a.js</code>, karma will run <code>&#39;a&#39;</code> then <code>&#39;b&#39;</code> then <code>&#39;c&#39;</code>.  If two lists contradict each other, like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then karma will arbitrarily pick one list to prioritize over the other.  In a
 case like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'c'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'d'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then <code>&#39;a&#39;</code> will definitely be run first, <code>&#39;d&#39;</code> will definitely be run last, but
 it&#39;s arbitrary if karma will run <code>&#39;b&#39;</code> before <code>&#39;c&#39;</code> or vice versa.</p>
 

--- a/1.0/dev/git-commit-msg.html
+++ b/1.0/dev/git-commit-msg.html
@@ -133,14 +133,16 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Example commit message:</h2>
 <pre><code class="language-bash">fix(middleware): ensure Range headers adhere more closely to RFC 2616
 
 Add one new dependency, use `range-parser` (Express dependency) to compute
 range. It is more well-tested <span class="hljs-keyword">in</span> the wild.
 
-Fixes <span class="hljs-comment">#2310</span></code></pre>
+Fixes <span class="hljs-comment">#2310</span>
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>The first line cannot be longer than 70 characters, the second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -181,9 +183,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in the case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -193,7 +197,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/1.0/dev/making-changes.html
+++ b/1.0/dev/making-changes.html
@@ -139,14 +139,16 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 $ rm -rf node_modules/karma
 $ <span class="hljs-built_in">cd</span> node_modules
 $ ln -s ../ karma
 $ <span class="hljs-built_in">cd</span> ../
-$ grunt browserify</code></pre>
+$ grunt browserify
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -159,13 +161,16 @@ $ grunt <span class="hljs-built_in">test</span>:e2e
 $ grunt <span class="hljs-built_in">test</span>:client
 
 <span class="hljs-comment"># All tests.</span>
-$ grunt <span class="hljs-built_in">test</span></code></pre>
+$ grunt <span class="hljs-built_in">test</span>
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
-<pre><code class="language-bash">$ npm run lint</code></pre>
+<pre><code class="language-bash">$ npm run lint
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
-<pre><code class="language-bash">$ npm build</code></pre>
+<pre><code class="language-bash">$ npm build
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -173,7 +178,8 @@ $ grunt <span class="hljs-built_in">test</span></code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -183,9 +189,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/1.0/dev/plugins.html
+++ b/1.0/dev/plugins.html
@@ -181,7 +181,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 
         </div>
       </div>

--- a/1.0/dev/public-api.html
+++ b/1.0/dev/public-api.html
@@ -131,19 +131,23 @@ You can, however, call Karma programmatically from your node module. Here is the
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p>Notice the capital &#39;S&#39; on  <code>require(&#39;karma&#39;).Server</code>.</p>
 <h3><strong>server.start()</strong></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><strong>server.refreshFiles()</strong></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>listening</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -205,7 +209,8 @@ You can, however, call Karma programmatically from your node module. Here is the
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.stopper</h2>
 <h3><strong>stopper.stop(options, [callback=process.exit])</strong></h3>
 <p>This function will signal a running server to stop.  The equivalent of <code>karma stop</code>.  </p>
@@ -215,7 +220,8 @@ stopper.stop({<span class="hljs-attr">port</span>: <span class="hljs-number">987
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Server stop as initiated'</span>)
   }
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.config.parseConfig([configFilePath], [cliOptions])</h2>
 <p>This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
@@ -224,7 +230,8 @@ uses this to load your karma configuration and use that in the stryker configura
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> cfg = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>).config;
 <span class="hljs-keyword">const</span> path = <span class="hljs-built_in">require</span>(<span class="hljs-string">'path'</span>);
 <span class="hljs-comment">// Read karma.conf.js, but override port with 1337</span>
-<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );</code></pre>
+<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );
+</code></pre>
 <h2>karma.constants</h2>
 <h3><strong>constants.VERSION</strong></h3>
 <p>The current version of karma</p>

--- a/1.0/intro/configuration.html
+++ b/1.0/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy-paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/1.0/intro/installation.html
+++ b/1.0/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/1.0/plus/cloud9.html
+++ b/1.0/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript and uses NodeJS on the back-end.</p>
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/1.0/plus/codio.html
+++ b/1.0/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from the right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from the right button).</p>

--- a/1.0/plus/emberjs.html
+++ b/1.0/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/1.0/plus/jenkins.html
+++ b/1.0/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -160,7 +161,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/1.0/plus/requirejs.html
+++ b/1.0/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks work just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -268,7 +272,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -295,14 +300,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/1.0/plus/semaphore.html
+++ b/1.0/plus/semaphore.html
@@ -133,26 +133,29 @@ you already have a Semaphore account.</p>
 create one now. This will both document your configuration and
 make it easy to run your tests. Here&#39;s an example:</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.10"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.10&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
-<pre><code class="language-json">"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers Firefox"
-}</code></pre>
+<pre><code class="language-json">&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers Firefox&quot;
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it on a virtual screen
 during your builds.</p>

--- a/1.0/plus/teamcity.html
+++ b/1.0/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during the build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to the build configuration: use Command Line runner and fill in <code>Custom script</code> text area. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> at the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/1.0/plus/travis.html
+++ b/1.0/plus/travis.html
@@ -135,19 +135,21 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root, create one now. Travis runs <code>npm test</code> to trigger your tests, so this
 is where you tell Travis how to run your tests.</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.12"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.12&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite, so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -160,10 +162,12 @@ like this:</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/2.0/about/changelog.html
+++ b/2.0/about/changelog.html
@@ -595,11 +595,13 @@ to match this new format.</p>
 <ul>
 <li><p>The public api interface has changed to a constructor form. To upgrade change</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 <p>to</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 <p>Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</p>
 </li>
@@ -1229,7 +1231,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1274,7 +1277,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/2.0/about/migration.html
+++ b/2.0/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/2.0/about/versioning.html
+++ b/2.0/about/versioning.html
@@ -125,9 +125,11 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org">Semantic Versioning</a>.</p>
 <p>It is recommended that you add Karma by running:</p>
-<pre><code class="language-bash">$ yarn add --dev karma</code></pre>
+<pre><code class="language-bash">$ yarn add --dev karma
+</code></pre>
 <p>or: </p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/2.0/config/browsers.html
+++ b/2.0/config/browsers.html
@@ -124,7 +124,8 @@
       </div>
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time-consuming task. However, Karma can automate this for you. Simply add the browsers you would like to capture into the <a href="configuration-file.html">configuration file</a>.</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them after the job is over.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -142,13 +143,15 @@
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then, inside your configuration file, add the browser name in <code>browsers</code> array.</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also, keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -161,7 +164,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can also be configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -173,7 +177,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. Here is a code snippet example explaining how to set a display name for a custom launcher.</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -182,7 +187,8 @@ user agent. Here is a code snippet example explaining how to set a display name 
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>If the definition is as above, the browser will be displayed as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -195,17 +201,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID-parameter to be used to connect to the server. The supplied ID is used by the server to keep track of which specific browser is captured.</p>
 
         </div>

--- a/2.0/config/configuration-file.html
+++ b/2.0/config/configuration-file.html
@@ -148,13 +148,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <pre><code class="language-typescript"><span class="hljs-comment">// karma.conf.ts</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
   config.set({
@@ -162,7 +164,8 @@ which accepts one argument: the configuration object.</p>
     frameworks: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-}</code></pre>
+}
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -216,7 +219,8 @@ properties, all of which are optional:</p>
   <span class="hljs-attr">format</span>: string,
   <span class="hljs-attr">path</span>:   string,
   <span class="hljs-attr">terminal</span>: boolean
-}</code></pre>
+}
+</code></pre>
 <p>Here the <code>level</code> is the desired log-level, where level <code>log</code> always is logged. The format
 is a string where <code>%b</code>, <code>%t</code>, <code>%T</code>, and <code>%m</code> are replaced with the browser string,
 log type in lower-case, log type in uppercase, and log message, respectively. This format will
@@ -335,7 +339,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>detached</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>false</code></p>
@@ -384,7 +389,8 @@ will return exit-code <code>0</code> and display a warning.</p>
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -414,12 +420,14 @@ will return exit-code <code>0</code> and display a warning.</p>
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -429,7 +437,8 @@ will return exit-code <code>0</code> and display a warning.</p>
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>beforeMiddleware</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -500,7 +509,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>
@@ -565,7 +575,8 @@ between browsers and the testing server).</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-javascript">proxyReq: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">proxyReq, req, res, options</span>) </span>{
   proxyReq.setHeader(<span class="hljs-string">'Referer'</span>, <span class="hljs-string">'https://www.example.com/'</span>);
-}</code></pre>
+}
+</code></pre>
 <h2>proxyRes</h2>
 <p><strong>Type:</strong> Function</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -578,7 +589,8 @@ between browsers and the testing server).</p>
       <span class="hljs-keyword">return</span> cookie.replace(<span class="hljs-regexp">/\s*secure;?/i</span>, <span class="hljs-string">''</span>);
     })
   }
-}</code></pre>
+}
+</code></pre>
 <h2>upstreamProxy</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>undefined</code></p>

--- a/2.0/config/files.html
+++ b/2.0/config/files.html
@@ -217,26 +217,30 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading Assets</h2>
 <p>By default all assets are served at <code>http://localhost:[PORT]/base/</code></p>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However, they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition, you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <h2>Webserver features</h2>
 <ul>
 <li><a href="https://en.wikipedia.org/wiki/Byte_serving">Range requests</a>.</li>

--- a/2.0/config/plugins.html
+++ b/2.0/config/plugins.html
@@ -134,9 +134,11 @@ In fact, all the existing preprocessors, reporters, browser launchers and framew
     <span class="hljs-string">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-string">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads all sibling NPM modules which have a name starting with <code>karma-*</code>.</p>
 <p>You can also explicitly list plugins you want to load via the <code>plugins</code> configuration setting. The configuration value can either be
@@ -149,7 +151,8 @@ a string (module name), which will be required by Karma, or an object (inlined p
   <span class="hljs-comment">// inlined plugins</span>
   {<span class="hljs-string">'framework:xyz'</span>: [<span class="hljs-string">'factory'</span>, factoryFn]},
   <span class="hljs-built_in">require</span>(<span class="hljs-string">'./plugin-required-from-config'</span>)
-]</code></pre>
+]
+</code></pre>
 <p>There are already many <a href="https://npmjs.org/browse/keyword/karma-plugin">existing plugins</a>. Of course, you can write <a href="../dev/plugins.html">your own plugins</a> too!</p>
 
         </div>

--- a/2.0/config/preprocessors.html
+++ b/2.0/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can also be configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Mini matching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>
@@ -190,25 +195,29 @@ will execute the preprocessors over that file in the order they are listed in
 the corresponding array. So for instance, if the config object is:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then karma will execute <code>&#39;a&#39;</code> before executing <code>&#39;b&#39;</code>.</p>
 <p>If a file matches multiple keys, karma will do its best to execute the
 preprocessors in a reasonable order.  So if you have:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then for <code>a.js</code>, karma will run <code>&#39;a&#39;</code> then <code>&#39;b&#39;</code> then <code>&#39;c&#39;</code>.  If two lists contradict each other, like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then karma will arbitrarily pick one list to prioritize over the other.  In a
 case like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'c'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'d'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then <code>&#39;a&#39;</code> will definitely be run first, <code>&#39;d&#39;</code> will definitely be run last, but
 it&#39;s arbitrary if karma will run <code>&#39;b&#39;</code> before <code>&#39;c&#39;</code> or vice versa.</p>
 

--- a/2.0/dev/git-commit-msg.html
+++ b/2.0/dev/git-commit-msg.html
@@ -133,14 +133,16 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Example commit message:</h2>
 <pre><code class="language-bash">fix(middleware): ensure Range headers adhere more closely to RFC 2616
 
 Add one new dependency, use `range-parser` (Express dependency) to compute
 range. It is more well-tested <span class="hljs-keyword">in</span> the wild.
 
-Fixes <span class="hljs-comment">#2310</span></code></pre>
+Fixes <span class="hljs-comment">#2310</span>
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>The first line cannot be longer than 70 characters, the second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -181,9 +183,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in the case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -193,7 +197,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/2.0/dev/making-changes.html
+++ b/2.0/dev/making-changes.html
@@ -140,14 +140,16 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 $ rm -rf node_modules/karma
 $ <span class="hljs-built_in">cd</span> node_modules
 $ ln -s ../ karma
 $ <span class="hljs-built_in">cd</span> ../
-$ grunt browserify</code></pre>
+$ grunt browserify
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -160,13 +162,16 @@ $ grunt <span class="hljs-built_in">test</span>:e2e
 $ grunt <span class="hljs-built_in">test</span>:client
 
 <span class="hljs-comment"># All tests.</span>
-$ grunt <span class="hljs-built_in">test</span></code></pre>
+$ grunt <span class="hljs-built_in">test</span>
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
-<pre><code class="language-bash">$ npm run lint</code></pre>
+<pre><code class="language-bash">$ npm run lint
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
-<pre><code class="language-bash">$ npm build</code></pre>
+<pre><code class="language-bash">$ npm build
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -174,7 +179,8 @@ $ grunt <span class="hljs-built_in">test</span></code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -184,9 +190,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/2.0/dev/plugins.html
+++ b/2.0/dev/plugins.html
@@ -181,7 +181,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 
         </div>
       </div>

--- a/2.0/dev/public-api.html
+++ b/2.0/dev/public-api.html
@@ -131,19 +131,23 @@ You can, however, call Karma programmatically from your node module. Here is the
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p>Notice the capital &#39;S&#39; on  <code>require(&#39;karma&#39;).Server</code>.</p>
 <h3><strong>server.start()</strong></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><strong>server.refreshFiles()</strong></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>listening</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -205,7 +209,8 @@ You can, however, call Karma programmatically from your node module. Here is the
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.stopper</h2>
 <h3><strong>stopper.stop(options, [callback=process.exit])</strong></h3>
 <p>This function will signal a running server to stop.  The equivalent of <code>karma stop</code>.  </p>
@@ -215,7 +220,8 @@ stopper.stop({<span class="hljs-attr">port</span>: <span class="hljs-number">987
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Server stop as initiated'</span>)
   }
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.config.parseConfig([configFilePath], [cliOptions])</h2>
 <p>This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
@@ -224,7 +230,8 @@ uses this to load your karma configuration and use that in the stryker configura
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> cfg = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>).config;
 <span class="hljs-keyword">const</span> path = <span class="hljs-built_in">require</span>(<span class="hljs-string">'path'</span>);
 <span class="hljs-comment">// Read karma.conf.js, but override port with 1337</span>
-<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );</code></pre>
+<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );
+</code></pre>
 <h2>karma.constants</h2>
 <h3><strong>constants.VERSION</strong></h3>
 <p>The current version of karma</p>

--- a/2.0/intro/configuration.html
+++ b/2.0/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy-paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/2.0/intro/installation.html
+++ b/2.0/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/2.0/plus/cloud9.html
+++ b/2.0/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript and uses NodeJS on the back-end.</p>
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/2.0/plus/codio.html
+++ b/2.0/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from the right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from the right button).</p>

--- a/2.0/plus/emberjs.html
+++ b/2.0/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/2.0/plus/jenkins.html
+++ b/2.0/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -160,7 +161,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/2.0/plus/requirejs.html
+++ b/2.0/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks work just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -268,7 +272,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -295,14 +300,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/2.0/plus/semaphore.html
+++ b/2.0/plus/semaphore.html
@@ -133,26 +133,29 @@ you already have a Semaphore account.</p>
 create one now. This will both document your configuration and
 make it easy to run your tests. Here&#39;s an example:</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.10"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.10&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
-<pre><code class="language-json">"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers Firefox"
-}</code></pre>
+<pre><code class="language-json">&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers Firefox&quot;
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it on a virtual screen
 during your builds.</p>

--- a/2.0/plus/teamcity.html
+++ b/2.0/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during the build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to the build configuration: use Command Line runner and fill in <code>Custom script</code> text area. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> at the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/2.0/plus/travis.html
+++ b/2.0/plus/travis.html
@@ -135,19 +135,21 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root, create one now. Travis runs <code>npm test</code> to trigger your tests, so this
 is where you tell Travis how to run your tests.</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.12"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.12&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite, so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -160,10 +162,12 @@ like this:</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/3.0/about/changelog.html
+++ b/3.0/about/changelog.html
@@ -746,11 +746,13 @@ to match this new format.</p>
 <ul>
 <li><p>The public api interface has changed to a constructor form. To upgrade change</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 <p>to</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 <p>Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</p>
 </li>
@@ -1380,7 +1382,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1425,7 +1428,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/3.0/about/migration.html
+++ b/3.0/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/3.0/about/versioning.html
+++ b/3.0/about/versioning.html
@@ -125,9 +125,11 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org">Semantic Versioning</a>.</p>
 <p>It is recommended that you add Karma by running:</p>
-<pre><code class="language-bash">$ yarn add --dev karma</code></pre>
+<pre><code class="language-bash">$ yarn add --dev karma
+</code></pre>
 <p>or: </p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/3.0/config/browsers.html
+++ b/3.0/config/browsers.html
@@ -124,7 +124,8 @@
       </div>
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time-consuming task. However, Karma can automate this for you. Simply add the browsers you would like to capture into the <a href="configuration-file.html">configuration file</a>.</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them after the job is over.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -142,13 +143,15 @@
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then, inside your configuration file, add the browser name in <code>browsers</code> array.</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also, keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -161,7 +164,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can also be configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -173,7 +177,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. Here is a code snippet example explaining how to set a display name for a custom launcher.</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -182,7 +187,8 @@ user agent. Here is a code snippet example explaining how to set a display name 
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>If the definition is as above, the browser will be displayed as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -195,17 +201,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID-parameter to be used to connect to the server. The supplied ID is used by the server to keep track of which specific browser is captured.</p>
 
         </div>

--- a/3.0/config/configuration-file.html
+++ b/3.0/config/configuration-file.html
@@ -148,13 +148,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <pre><code class="language-typescript"><span class="hljs-comment">// karma.conf.ts</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
   config.set({
@@ -162,7 +164,8 @@ which accepts one argument: the configuration object.</p>
     frameworks: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-}</code></pre>
+}
+</code></pre>
 <h3>Customized TypeScript Configuration</h3>
 <p>Under the hood Karma uses ts-node to transpile TypeScript to JavaScript. If the resolved <code>tsconfig.json</code> has <code>module</code> configured as <code>ES</code> formats. You might get errors like <code>SyntaxError: Unexpected token</code>. This is due that in Node <code>ES</code> module formats are not supported. To overcome this issue you need to configure ts-node to use <code>commonjs</code> module format.</p>
 <p>Create a JavaScript configuration file that overrides the module format.</p>
@@ -172,7 +175,8 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">module</span>: <span class="hljs-string">'commonjs'</span> 
   } 
 });
-<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);</code></pre>
+<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -226,7 +230,8 @@ properties, all of which are optional:</p>
   <span class="hljs-attr">format</span>: string,
   <span class="hljs-attr">path</span>:   string,
   <span class="hljs-attr">terminal</span>: boolean
-}</code></pre>
+}
+</code></pre>
 <p>Here the <code>level</code> is the desired log-level, where level <code>log</code> always is logged. The format
 is a string where <code>%b</code>, <code>%t</code>, <code>%T</code>, and <code>%m</code> are replaced with the browser string,
 log type in lower-case, log type in uppercase, and log message, respectively. This format will
@@ -346,7 +351,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>detached</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>false</code></p>
@@ -395,7 +401,8 @@ will return exit-code <code>0</code> and display a warning.</p>
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -425,12 +432,14 @@ will return exit-code <code>0</code> and display a warning.</p>
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -440,7 +449,8 @@ will return exit-code <code>0</code> and display a warning.</p>
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>beforeMiddleware</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -511,7 +521,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>
@@ -576,7 +587,8 @@ between browsers and the testing server).</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-javascript">proxyReq: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">proxyReq, req, res, options</span>) </span>{
   proxyReq.setHeader(<span class="hljs-string">'Referer'</span>, <span class="hljs-string">'https://www.example.com/'</span>);
-}</code></pre>
+}
+</code></pre>
 <h2>proxyRes</h2>
 <p><strong>Type:</strong> Function</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -589,7 +601,8 @@ between browsers and the testing server).</p>
       <span class="hljs-keyword">return</span> cookie.replace(<span class="hljs-regexp">/\s*secure;?/i</span>, <span class="hljs-string">''</span>);
     })
   }
-}</code></pre>
+}
+</code></pre>
 <h2>upstreamProxy</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -631,7 +644,8 @@ Trying to start ChromeHeadless again (<span class="hljs-number">1</span>/<span c
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
 Trying to start ChromeHeadless again (<span class="hljs-number">2</span>/<span class="hljs-number">2</span>).
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
-ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.</code></pre>
+ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.
+</code></pre>
 <p>If you see this error, you can try increasing the socket connection timeout.</p>
 
         </div>

--- a/3.0/config/files.html
+++ b/3.0/config/files.html
@@ -227,26 +227,30 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading Assets</h2>
 <p>By default all assets are served at <code>http://localhost:[PORT]/base/</code></p>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However, they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition, you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <h2>Webserver features</h2>
 <ul>
 <li><a href="https://en.wikipedia.org/wiki/Byte_serving">Range requests</a>.</li>

--- a/3.0/config/plugins.html
+++ b/3.0/config/plugins.html
@@ -134,9 +134,11 @@ In fact, all the existing preprocessors, reporters, browser launchers and framew
     <span class="hljs-string">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-string">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads all sibling NPM modules which have a name starting with <code>karma-*</code>.</p>
 <p>You can also explicitly list plugins you want to load via the <code>plugins</code> configuration setting. The configuration value can either be
@@ -149,7 +151,8 @@ a string (module name), which will be required by Karma, or an object (inlined p
   <span class="hljs-comment">// inlined plugins</span>
   {<span class="hljs-string">'framework:xyz'</span>: [<span class="hljs-string">'factory'</span>, factoryFn]},
   <span class="hljs-built_in">require</span>(<span class="hljs-string">'./plugin-required-from-config'</span>)
-]</code></pre>
+]
+</code></pre>
 <p>There are already many <a href="https://npmjs.org/browse/keyword/karma-plugin">existing plugins</a>. Of course, you can write <a href="../dev/plugins.html">your own plugins</a> too!</p>
 
         </div>

--- a/3.0/config/preprocessors.html
+++ b/3.0/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can also be configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Mini matching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>
@@ -190,25 +195,29 @@ will execute the preprocessors over that file in the order they are listed in
 the corresponding array. So for instance, if the config object is:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then karma will execute <code>&#39;a&#39;</code> before executing <code>&#39;b&#39;</code>.</p>
 <p>If a file matches multiple keys, karma will do its best to execute the
 preprocessors in a reasonable order.  So if you have:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then for <code>a.js</code>, karma will run <code>&#39;a&#39;</code> then <code>&#39;b&#39;</code> then <code>&#39;c&#39;</code>.  If two lists contradict each other, like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then karma will arbitrarily pick one list to prioritize over the other.  In a
 case like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'c'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'d'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then <code>&#39;a&#39;</code> will definitely be run first, <code>&#39;d&#39;</code> will definitely be run last, but
 it&#39;s arbitrary if karma will run <code>&#39;b&#39;</code> before <code>&#39;c&#39;</code> or vice versa.</p>
 

--- a/3.0/dev/git-commit-msg.html
+++ b/3.0/dev/git-commit-msg.html
@@ -133,14 +133,16 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Example commit message:</h2>
 <pre><code class="language-bash">fix(middleware): ensure Range headers adhere more closely to RFC 2616
 
 Add one new dependency, use `range-parser` (Express dependency) to compute
 range. It is more well-tested <span class="hljs-keyword">in</span> the wild.
 
-Fixes <span class="hljs-comment">#2310</span></code></pre>
+Fixes <span class="hljs-comment">#2310</span>
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>The first line cannot be longer than 70 characters, the second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -181,9 +183,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in the case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -193,7 +197,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/3.0/dev/making-changes.html
+++ b/3.0/dev/making-changes.html
@@ -140,14 +140,16 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 $ rm -rf node_modules/karma
 $ <span class="hljs-built_in">cd</span> node_modules
 $ ln -s ../ karma
 $ <span class="hljs-built_in">cd</span> ../
-$ grunt browserify</code></pre>
+$ grunt browserify
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -160,13 +162,16 @@ $ grunt <span class="hljs-built_in">test</span>:e2e
 $ grunt <span class="hljs-built_in">test</span>:client
 
 <span class="hljs-comment"># All tests.</span>
-$ grunt <span class="hljs-built_in">test</span></code></pre>
+$ grunt <span class="hljs-built_in">test</span>
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
-<pre><code class="language-bash">$ npm run lint</code></pre>
+<pre><code class="language-bash">$ npm run lint
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
-<pre><code class="language-bash">$ npm build</code></pre>
+<pre><code class="language-bash">$ npm build
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -174,7 +179,8 @@ $ grunt <span class="hljs-built_in">test</span></code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -184,9 +190,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/3.0/dev/plugins.html
+++ b/3.0/dev/plugins.html
@@ -194,7 +194,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 
         </div>
       </div>

--- a/3.0/dev/public-api.html
+++ b/3.0/dev/public-api.html
@@ -132,22 +132,27 @@ You can, however, call Karma programmatically from your node module. Here is the
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(karmaConfig, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p>Notice the capital &#39;S&#39; on  <code>require(&#39;karma&#39;).Server</code>.</p>
 <h3><strong>server.start()</strong></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><strong>server.refreshFiles()</strong></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3><strong>server.refreshFile(path)</strong></h3>
 <p>Trigger a file refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)</code></pre>
+<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>listening</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -209,7 +214,8 @@ You can, however, call Karma programmatically from your node module. Here is the
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.stopper</h2>
 <h3><strong>stopper.stop(options, [callback=process.exit])</strong></h3>
 <p>This function will signal a running server to stop.  The equivalent of <code>karma stop</code>.  </p>
@@ -219,7 +225,8 @@ stopper.stop({<span class="hljs-attr">port</span>: <span class="hljs-number">987
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Server stop as initiated'</span>)
   }
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.config.parseConfig([configFilePath], [cliOptions])</h2>
 <p>This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
@@ -228,7 +235,8 @@ uses this to load your karma configuration and use that in the stryker configura
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> cfg = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>).config;
 <span class="hljs-keyword">const</span> path = <span class="hljs-built_in">require</span>(<span class="hljs-string">'path'</span>);
 <span class="hljs-comment">// Read karma.conf.js, but override port with 1337</span>
-<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );</code></pre>
+<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );
+</code></pre>
 <h2>karma.constants</h2>
 <h3><strong>constants.VERSION</strong></h3>
 <p>The current version of karma</p>

--- a/3.0/intro/configuration.html
+++ b/3.0/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy-paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/3.0/intro/installation.html
+++ b/3.0/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/3.0/plus/cloud9.html
+++ b/3.0/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript and uses NodeJS on the back-end.</p>
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/3.0/plus/codio.html
+++ b/3.0/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from the right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from the right button).</p>

--- a/3.0/plus/emberjs.html
+++ b/3.0/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/3.0/plus/jenkins.html
+++ b/3.0/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -160,7 +161,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/3.0/plus/requirejs.html
+++ b/3.0/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks work just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -268,7 +272,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -295,14 +300,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/3.0/plus/semaphore.html
+++ b/3.0/plus/semaphore.html
@@ -133,26 +133,29 @@ you already have a Semaphore account.</p>
 create one now. This will both document your configuration and
 make it easy to run your tests. Here&#39;s an example:</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.10"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.10&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
-<pre><code class="language-json">"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers Firefox"
-}</code></pre>
+<pre><code class="language-json">&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers Firefox&quot;
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it on a virtual screen
 during your builds.</p>

--- a/3.0/plus/teamcity.html
+++ b/3.0/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during the build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to the build configuration: use Command Line runner and fill in <code>Custom script</code> text area. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> at the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/3.0/plus/travis.html
+++ b/3.0/plus/travis.html
@@ -135,19 +135,21 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root, create one now. Travis runs <code>npm test</code> to trigger your tests, so this
 is where you tell Travis how to run your tests.</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.12"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.12&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite, so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -160,10 +162,12 @@ like this:</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/4.0/about/changelog.html
+++ b/4.0/about/changelog.html
@@ -780,11 +780,13 @@ to match this new format.</p>
 <ul>
 <li><p>The public api interface has changed to a constructor form. To upgrade change</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 <p>to</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 <p>Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</p>
 </li>
@@ -1414,7 +1416,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1459,7 +1462,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/4.0/about/migration.html
+++ b/4.0/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/4.0/about/versioning.html
+++ b/4.0/about/versioning.html
@@ -125,9 +125,11 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org">Semantic Versioning</a>.</p>
 <p>It is recommended that you add Karma by running:</p>
-<pre><code class="language-bash">$ yarn add --dev karma</code></pre>
+<pre><code class="language-bash">$ yarn add --dev karma
+</code></pre>
 <p>or: </p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/4.0/config/browsers.html
+++ b/4.0/config/browsers.html
@@ -124,7 +124,8 @@
       </div>
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time-consuming task. However, Karma can automate this for you. Simply add the browsers you would like to capture into the <a href="configuration-file.html">configuration file</a>.</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them after the job is over.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -142,13 +143,15 @@
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then, inside your configuration file, add the browser name in <code>browsers</code> array.</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also, keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -161,7 +164,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can also be configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -173,7 +177,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. Here is a code snippet example explaining how to set a display name for a custom launcher.</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -182,7 +187,8 @@ user agent. Here is a code snippet example explaining how to set a display name 
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>If the definition is as above, the browser will be displayed as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -195,17 +201,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID-parameter to be used to connect to the server. The supplied ID is used by the server to keep track of which specific browser is captured.</p>
 
         </div>

--- a/4.0/config/configuration-file.html
+++ b/4.0/config/configuration-file.html
@@ -148,13 +148,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <pre><code class="language-typescript"><span class="hljs-comment">// karma.conf.ts</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
   config.set({
@@ -162,7 +164,8 @@ which accepts one argument: the configuration object.</p>
     frameworks: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-}</code></pre>
+}
+</code></pre>
 <h3>Customized TypeScript Configuration</h3>
 <p>Under the hood Karma uses ts-node to transpile TypeScript to JavaScript. If the resolved <code>tsconfig.json</code> has <code>module</code> configured as <code>ES</code> formats. You might get errors like <code>SyntaxError: Unexpected token</code>. This is due that in Node <code>ES</code> module formats are not supported. To overcome this issue you need to configure ts-node to use <code>commonjs</code> module format.</p>
 <p>Create a JavaScript configuration file that overrides the module format.</p>
@@ -172,7 +175,8 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">module</span>: <span class="hljs-string">'commonjs'</span> 
   } 
 });
-<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);</code></pre>
+<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -226,7 +230,8 @@ properties, all of which are optional:</p>
   <span class="hljs-attr">format</span>: string,
   <span class="hljs-attr">path</span>:   string,
   <span class="hljs-attr">terminal</span>: boolean
-}</code></pre>
+}
+</code></pre>
 <p>Here the <code>level</code> is the desired log-level, where level <code>log</code> always is logged. The format
 is a string where <code>%b</code>, <code>%t</code>, <code>%T</code>, and <code>%m</code> are replaced with the browser string,
 log type in lower-case, log type in uppercase, and log message, respectively. This format will
@@ -346,7 +351,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>detached</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>false</code></p>
@@ -395,7 +401,8 @@ will return exit-code <code>0</code> and display a warning.</p>
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -425,12 +432,14 @@ will return exit-code <code>0</code> and display a warning.</p>
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -440,7 +449,8 @@ will return exit-code <code>0</code> and display a warning.</p>
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>beforeMiddleware</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -511,7 +521,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>
@@ -576,7 +587,8 @@ between browsers and the testing server).</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-javascript">proxyReq: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">proxyReq, req, res, options</span>) </span>{
   proxyReq.setHeader(<span class="hljs-string">'Referer'</span>, <span class="hljs-string">'https://www.example.com/'</span>);
-}</code></pre>
+}
+</code></pre>
 <h2>proxyRes</h2>
 <p><strong>Type:</strong> Function</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -589,7 +601,8 @@ between browsers and the testing server).</p>
       <span class="hljs-keyword">return</span> cookie.replace(<span class="hljs-regexp">/\s*secure;?/i</span>, <span class="hljs-string">''</span>);
     })
   }
-}</code></pre>
+}
+</code></pre>
 <h2>upstreamProxy</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -631,7 +644,8 @@ Trying to start ChromeHeadless again (<span class="hljs-number">1</span>/<span c
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
 Trying to start ChromeHeadless again (<span class="hljs-number">2</span>/<span class="hljs-number">2</span>).
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
-ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.</code></pre>
+ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.
+</code></pre>
 <p>If you see this error, you can try increasing the socket connection timeout.</p>
 
         </div>

--- a/4.0/config/files.html
+++ b/4.0/config/files.html
@@ -227,26 +227,30 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading Assets</h2>
 <p>By default all assets are served at <code>http://localhost:[PORT]/base/</code></p>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However, they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition, you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <h2>Webserver features</h2>
 <ul>
 <li><a href="https://en.wikipedia.org/wiki/Byte_serving">Range requests</a>.</li>

--- a/4.0/config/plugins.html
+++ b/4.0/config/plugins.html
@@ -134,9 +134,11 @@ In fact, all the existing preprocessors, reporters, browser launchers and framew
     <span class="hljs-string">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-string">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads all sibling NPM modules which have a name starting with <code>karma-*</code>.</p>
 <p>You can also explicitly list plugins you want to load via the <code>plugins</code> configuration setting. The configuration value can either be
@@ -149,7 +151,8 @@ a string (module name), which will be required by Karma, or an object (inlined p
   <span class="hljs-comment">// inlined plugins</span>
   {<span class="hljs-string">'framework:xyz'</span>: [<span class="hljs-string">'factory'</span>, factoryFn]},
   <span class="hljs-built_in">require</span>(<span class="hljs-string">'./plugin-required-from-config'</span>)
-]</code></pre>
+]
+</code></pre>
 <p>There are already many <a href="https://npmjs.org/browse/keyword/karma-plugin">existing plugins</a>. Of course, you can write <a href="../dev/plugins.html">your own plugins</a> too!</p>
 
         </div>

--- a/4.0/config/preprocessors.html
+++ b/4.0/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can also be configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Mini matching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>
@@ -190,25 +195,29 @@ will execute the preprocessors over that file in the order they are listed in
 the corresponding array. So for instance, if the config object is:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then karma will execute <code>&#39;a&#39;</code> before executing <code>&#39;b&#39;</code>.</p>
 <p>If a file matches multiple keys, karma will do its best to execute the
 preprocessors in a reasonable order.  So if you have:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then for <code>a.js</code>, karma will run <code>&#39;a&#39;</code> then <code>&#39;b&#39;</code> then <code>&#39;c&#39;</code>.  If two lists contradict each other, like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then karma will arbitrarily pick one list to prioritize over the other.  In a
 case like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'c'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'d'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then <code>&#39;a&#39;</code> will definitely be run first, <code>&#39;d&#39;</code> will definitely be run last, but
 it&#39;s arbitrary if karma will run <code>&#39;b&#39;</code> before <code>&#39;c&#39;</code> or vice versa.</p>
 

--- a/4.0/dev/git-commit-msg.html
+++ b/4.0/dev/git-commit-msg.html
@@ -133,14 +133,16 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Example commit message:</h2>
 <pre><code class="language-bash">fix(middleware): ensure Range headers adhere more closely to RFC 2616
 
 Add one new dependency, use `range-parser` (Express dependency) to compute
 range. It is more well-tested <span class="hljs-keyword">in</span> the wild.
 
-Fixes <span class="hljs-comment">#2310</span></code></pre>
+Fixes <span class="hljs-comment">#2310</span>
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>The first line cannot be longer than 70 characters, the second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -181,9 +183,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in the case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -193,7 +197,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/4.0/dev/making-changes.html
+++ b/4.0/dev/making-changes.html
@@ -140,14 +140,16 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 $ rm -rf node_modules/karma
 $ <span class="hljs-built_in">cd</span> node_modules
 $ ln -s ../ karma
 $ <span class="hljs-built_in">cd</span> ../
-$ grunt browserify</code></pre>
+$ grunt browserify
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -160,13 +162,16 @@ $ grunt <span class="hljs-built_in">test</span>:e2e
 $ grunt <span class="hljs-built_in">test</span>:client
 
 <span class="hljs-comment"># All tests.</span>
-$ grunt <span class="hljs-built_in">test</span></code></pre>
+$ grunt <span class="hljs-built_in">test</span>
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
-<pre><code class="language-bash">$ npm run lint</code></pre>
+<pre><code class="language-bash">$ npm run lint
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
-<pre><code class="language-bash">$ npm build</code></pre>
+<pre><code class="language-bash">$ npm build
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -174,7 +179,8 @@ $ grunt <span class="hljs-built_in">test</span></code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -184,9 +190,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/4.0/dev/plugins.html
+++ b/4.0/dev/plugins.html
@@ -194,7 +194,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 
         </div>
       </div>

--- a/4.0/dev/public-api.html
+++ b/4.0/dev/public-api.html
@@ -132,22 +132,27 @@ You can, however, call Karma programmatically from your node module. Here is the
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(karmaConfig, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p>Notice the capital &#39;S&#39; on  <code>require(&#39;karma&#39;).Server</code>.</p>
 <h3><strong>server.start()</strong></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><strong>server.refreshFiles()</strong></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3><strong>server.refreshFile(path)</strong></h3>
 <p>Trigger a file refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)</code></pre>
+<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>listening</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -209,7 +214,8 @@ You can, however, call Karma programmatically from your node module. Here is the
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.stopper</h2>
 <h3><strong>stopper.stop(options, [callback=process.exit])</strong></h3>
 <p>This function will signal a running server to stop.  The equivalent of <code>karma stop</code>.  </p>
@@ -219,7 +225,8 @@ stopper.stop({<span class="hljs-attr">port</span>: <span class="hljs-number">987
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Server stop as initiated'</span>)
   }
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.config.parseConfig([configFilePath], [cliOptions])</h2>
 <p>This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
@@ -228,7 +235,8 @@ uses this to load your karma configuration and use that in the stryker configura
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> cfg = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>).config;
 <span class="hljs-keyword">const</span> path = <span class="hljs-built_in">require</span>(<span class="hljs-string">'path'</span>);
 <span class="hljs-comment">// Read karma.conf.js, but override port with 1337</span>
-<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );</code></pre>
+<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );
+</code></pre>
 <h2>karma.constants</h2>
 <h3><strong>constants.VERSION</strong></h3>
 <p>The current version of karma</p>

--- a/4.0/intro/configuration.html
+++ b/4.0/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy-paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/4.0/intro/installation.html
+++ b/4.0/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/4.0/plus/cloud9.html
+++ b/4.0/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript and uses NodeJS on the back-end.</p>
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/4.0/plus/codio.html
+++ b/4.0/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from the right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from the right button).</p>

--- a/4.0/plus/emberjs.html
+++ b/4.0/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/4.0/plus/jenkins.html
+++ b/4.0/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -160,7 +161,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/4.0/plus/requirejs.html
+++ b/4.0/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks work just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -268,7 +272,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -295,14 +300,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/4.0/plus/semaphore.html
+++ b/4.0/plus/semaphore.html
@@ -133,26 +133,29 @@ you already have a Semaphore account.</p>
 create one now. This will both document your configuration and
 make it easy to run your tests. Here&#39;s an example:</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.10"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.10&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
-<pre><code class="language-json">"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers Firefox"
-}</code></pre>
+<pre><code class="language-json">&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers Firefox&quot;
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it on a virtual screen
 during your builds.</p>

--- a/4.0/plus/teamcity.html
+++ b/4.0/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during the build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to the build configuration: use Command Line runner and fill in <code>Custom script</code> text area. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> at the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/4.0/plus/travis.html
+++ b/4.0/plus/travis.html
@@ -135,19 +135,21 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root, create one now. Travis runs <code>npm test</code> to trigger your tests, so this
 is where you tell Travis how to run your tests.</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.12"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.12&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite, so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -160,10 +162,12 @@ like this:</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/5.0/about/changelog.html
+++ b/5.0/about/changelog.html
@@ -881,11 +881,13 @@ to match this new format.</p>
 <ul>
 <li><p>The public api interface has changed to a constructor form. To upgrade change</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 <p>to</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 <p>Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</p>
 </li>
@@ -1515,7 +1517,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1560,7 +1563,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/5.0/about/migration.html
+++ b/5.0/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/5.0/about/versioning.html
+++ b/5.0/about/versioning.html
@@ -125,9 +125,11 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org">Semantic Versioning</a>.</p>
 <p>It is recommended that you add Karma by running:</p>
-<pre><code class="language-bash">$ yarn add --dev karma</code></pre>
+<pre><code class="language-bash">$ yarn add --dev karma
+</code></pre>
 <p>or: </p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/5.0/config/browsers.html
+++ b/5.0/config/browsers.html
@@ -124,7 +124,8 @@
       </div>
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time-consuming task. However, Karma can automate this for you. Simply add the browsers you would like to capture into the <a href="configuration-file.html">configuration file</a>.</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them after the job is over.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -142,13 +143,15 @@
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then, inside your configuration file, add the browser name in <code>browsers</code> array.</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also, keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -161,7 +164,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can also be configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -173,7 +177,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. Here is a code snippet example explaining how to set a display name for a custom launcher.</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -182,7 +187,8 @@ user agent. Here is a code snippet example explaining how to set a display name 
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>If the definition is as above, the browser will be displayed as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -195,17 +201,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID-parameter to be used to connect to the server. The supplied ID is used by the server to keep track of which specific browser is captured.</p>
 
         </div>

--- a/5.0/config/configuration-file.html
+++ b/5.0/config/configuration-file.html
@@ -148,13 +148,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <pre><code class="language-typescript"><span class="hljs-comment">// karma.conf.ts</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
   config.set({
@@ -162,7 +164,8 @@ which accepts one argument: the configuration object.</p>
     frameworks: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-}</code></pre>
+}
+</code></pre>
 <h3>Customized TypeScript Configuration</h3>
 <p>Under the hood Karma uses ts-node to transpile TypeScript to JavaScript. If the resolved <code>tsconfig.json</code> has <code>module</code> configured as <code>ES</code> formats. You might get errors like <code>SyntaxError: Unexpected token</code>. This is due that in Node <code>ES</code> module formats are not supported. To overcome this issue you need to configure ts-node to use <code>commonjs</code> module format.</p>
 <p>Create a JavaScript configuration file that overrides the module format.</p>
@@ -172,7 +175,8 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">module</span>: <span class="hljs-string">'commonjs'</span>
   }
 });
-<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);</code></pre>
+<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -226,7 +230,8 @@ properties, all of which are optional:</p>
   <span class="hljs-attr">format</span>: string,
   <span class="hljs-attr">path</span>:   string,
   <span class="hljs-attr">terminal</span>: boolean
-}</code></pre>
+}
+</code></pre>
 <p>Here the <code>level</code> is the desired log-level, where level <code>log</code> always is logged. The format
 is a string where <code>%b</code>, <code>%t</code>, <code>%T</code>, and <code>%m</code> are replaced with the browser string,
 log type in lower-case, log type in uppercase, and log message, respectively. This format will
@@ -351,7 +356,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>detached</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>false</code></p>
@@ -411,7 +417,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -441,12 +448,14 @@ Use this to prevent accidental disabling tests needed to validate production.</p
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -456,7 +465,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>beforeMiddleware</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -527,7 +537,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>
@@ -597,7 +608,8 @@ between browsers and the testing server).</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-javascript">proxyReq: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">proxyReq, req, res, options</span>) </span>{
   proxyReq.setHeader(<span class="hljs-string">'Referer'</span>, <span class="hljs-string">'https://www.example.com/'</span>);
-}</code></pre>
+}
+</code></pre>
 <h2>proxyRes</h2>
 <p><strong>Type:</strong> Function</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -610,7 +622,8 @@ between browsers and the testing server).</p>
       <span class="hljs-keyword">return</span> cookie.replace(<span class="hljs-regexp">/\s*secure;?/i</span>, <span class="hljs-string">''</span>);
     })
   }
-}</code></pre>
+}
+</code></pre>
 <h2>upstreamProxy</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -652,7 +665,8 @@ Trying to start ChromeHeadless again (<span class="hljs-number">1</span>/<span c
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
 Trying to start ChromeHeadless again (<span class="hljs-number">2</span>/<span class="hljs-number">2</span>).
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
-ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.</code></pre>
+ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.
+</code></pre>
 <p>If you see this error, you can try increasing the socket connection timeout.</p>
 
         </div>

--- a/5.0/config/files.html
+++ b/5.0/config/files.html
@@ -227,26 +227,30 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading Assets</h2>
 <p>By default all assets are served at <code>http://localhost:[PORT]/base/</code></p>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However, they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition, you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <h2>Webserver features</h2>
 <ul>
 <li><a href="https://en.wikipedia.org/wiki/Byte_serving">Range requests</a>.</li>

--- a/5.0/config/plugins.html
+++ b/5.0/config/plugins.html
@@ -134,9 +134,11 @@ In fact, all the existing preprocessors, reporters, browser launchers and framew
     <span class="hljs-string">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-string">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads all sibling NPM modules which have a name starting with <code>karma-*</code>.</p>
 <p>You can also explicitly list plugins you want to load via the <code>plugins</code> configuration setting. The configuration value can either be
@@ -149,7 +151,8 @@ a string (module name), which will be required by Karma, or an object (inlined p
   <span class="hljs-comment">// inlined plugins</span>
   {<span class="hljs-string">'framework:xyz'</span>: [<span class="hljs-string">'factory'</span>, factoryFn]},
   <span class="hljs-built_in">require</span>(<span class="hljs-string">'./plugin-required-from-config'</span>)
-]</code></pre>
+]
+</code></pre>
 <p>There are already many <a href="https://npmjs.org/browse/keyword/karma-plugin">existing plugins</a>. Of course, you can write <a href="../dev/plugins.html">your own plugins</a> too!</p>
 
         </div>

--- a/5.0/config/preprocessors.html
+++ b/5.0/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can also be configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Mini matching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>
@@ -190,7 +195,8 @@ will execute the preprocessors over that file in the order they are listed in
 the corresponding array. So for instance, if the config object is:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then karma will execute <code>&#39;a&#39;</code> before executing <code>&#39;b&#39;</code>.</p>
 <p>If a file matches multiple keys, karma will use the <code>config.preprocessor_priority</code>
 map to set the order. If this config option is not set, karma do its best to
@@ -198,18 +204,21 @@ execute the preprocessors in a reasonable order.  So if you have:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then for <code>a.js</code>, karma will run <code>&#39;a&#39;</code> then <code>&#39;b&#39;</code> then <code>&#39;c&#39;</code>.  If two lists contradict each other, like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then karma will arbitrarily pick one list to prioritize over the other.  In a
 case like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'c'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'d'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then <code>&#39;a&#39;</code> will definitely be run first, <code>&#39;d&#39;</code> will definitely be run last, but
 it&#39;s arbitrary if karma will run <code>&#39;b&#39;</code> before <code>&#39;c&#39;</code> or vice versa.</p>
 

--- a/5.0/dev/git-commit-msg.html
+++ b/5.0/dev/git-commit-msg.html
@@ -133,14 +133,16 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Example commit message:</h2>
 <pre><code class="language-bash">fix(middleware): ensure Range headers adhere more closely to RFC 2616
 
 Add one new dependency, use `range-parser` (Express dependency) to compute
 range. It is more well-tested <span class="hljs-keyword">in</span> the wild.
 
-Fixes <span class="hljs-comment">#2310</span></code></pre>
+Fixes <span class="hljs-comment">#2310</span>
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>The first line cannot be longer than 70 characters, the second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -181,9 +183,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in the case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -193,7 +197,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/5.0/dev/making-changes.html
+++ b/5.0/dev/making-changes.html
@@ -140,7 +140,8 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 
@@ -148,7 +149,8 @@ $ npm run init
 <span class="hljs-comment"># or if you're on Windows</span>
 $ npm run init:windows
 
-$ npm run build</code></pre>
+$ npm run build
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -158,15 +160,18 @@ $ npm run build</code></pre>
 <span class="hljs-comment"># or you can run test suits individually</span>
 $ npm run <span class="hljs-built_in">test</span>:unit
 $ npm run <span class="hljs-built_in">test</span>:e2e
-$ npm run <span class="hljs-built_in">test</span>:client</code></pre>
+$ npm run <span class="hljs-built_in">test</span>:client
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
 <pre><code class="language-bash">$ npm run lint
 <span class="hljs-comment"># or you can also apply auto-fixes where possible</span>
-$ npm run lint:fix</code></pre>
+$ npm run lint:fix
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
-<pre><code class="language-bash">$ npm run build</code></pre>
+<pre><code class="language-bash">$ npm run build
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -174,7 +179,8 @@ $ npm run lint:fix</code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -184,9 +190,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/5.0/dev/plugins.html
+++ b/5.0/dev/plugins.html
@@ -194,7 +194,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 
         </div>
       </div>

--- a/5.0/dev/public-api.html
+++ b/5.0/dev/public-api.html
@@ -132,22 +132,27 @@ You can, however, call Karma programmatically from your node module. Here is the
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(karmaConfig, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p>Notice the capital &#39;S&#39; on  <code>require(&#39;karma&#39;).Server</code>.</p>
 <h3><strong>server.start()</strong></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><strong>server.refreshFiles()</strong></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3><strong>server.refreshFile(path)</strong></h3>
 <p>Trigger a file refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)</code></pre>
+<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>listening</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -209,13 +214,15 @@ You can, however, call Karma programmatically from your node module. Here is the
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p><code>runner.run()</code> returns an <code>EventEmitter</code> which emits a <code>progress</code> event passing
 the reporter output as a <code>Buffer</code> object.</p>
 <p>You may listen for that event to print the reporter output to the console:</p>
 <pre><code class="language-javascript">runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}).on(<span class="hljs-string">'progress'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">data</span>) </span>{
   process.stdout.write(data)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.stopper</h2>
 <h3><strong>stopper.stop(options, [callback=process.exit])</strong></h3>
 <p>This function will signal a running server to stop.  The equivalent of <code>karma stop</code>.  </p>
@@ -225,7 +232,8 @@ stopper.stop({<span class="hljs-attr">port</span>: <span class="hljs-number">987
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Server stop as initiated'</span>)
   }
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.config.parseConfig([configFilePath], [cliOptions])</h2>
 <p>This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
@@ -234,7 +242,8 @@ uses this to load your karma configuration and use that in the stryker configura
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> cfg = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>).config;
 <span class="hljs-keyword">const</span> path = <span class="hljs-built_in">require</span>(<span class="hljs-string">'path'</span>);
 <span class="hljs-comment">// Read karma.conf.js, but override port with 1337</span>
-<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );</code></pre>
+<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );
+</code></pre>
 <h2>karma.constants</h2>
 <h3><strong>constants.VERSION</strong></h3>
 <p>The current version of karma</p>

--- a/5.0/intro/configuration.html
+++ b/5.0/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy-paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/5.0/intro/installation.html
+++ b/5.0/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/5.0/plus/cloud9.html
+++ b/5.0/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript and uses NodeJS on the back-end.</p>
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/5.0/plus/codio.html
+++ b/5.0/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from the right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from the right button).</p>

--- a/5.0/plus/emberjs.html
+++ b/5.0/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/5.0/plus/jenkins.html
+++ b/5.0/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -160,7 +161,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/5.0/plus/requirejs.html
+++ b/5.0/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks work just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -268,7 +272,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -295,14 +300,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/5.0/plus/semaphore.html
+++ b/5.0/plus/semaphore.html
@@ -133,26 +133,29 @@ you already have a Semaphore account.</p>
 create one now. This will both document your configuration and
 make it easy to run your tests. Here&#39;s an example:</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.10"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.10&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
-<pre><code class="language-json">"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers Firefox"
-}</code></pre>
+<pre><code class="language-json">&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers Firefox&quot;
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it on a virtual screen
 during your builds.</p>

--- a/5.0/plus/teamcity.html
+++ b/5.0/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during the build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to the build configuration: use Command Line runner and fill in <code>Custom script</code> text area. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> at the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/5.0/plus/travis.html
+++ b/5.0/plus/travis.html
@@ -135,19 +135,21 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root, create one now. Travis runs <code>npm test</code> to trigger your tests, so this
 is where you tell Travis how to run your tests.</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.12"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.12&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite, so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -160,17 +162,20 @@ like this (if you&#39;re using Xenial):</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">dist:</span> xenial
 <span class="hljs-symbol">services:</span>
-  - xvfb</code></pre>
+  - xvfb
+</code></pre>
 <p>Or this, for Trusty and below:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/5.1/about/changelog.html
+++ b/5.1/about/changelog.html
@@ -917,11 +917,13 @@ to match this new format.</p>
 <ul>
 <li><p>The public api interface has changed to a constructor form. To upgrade change</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 <p>to</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 <p>Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</p>
 </li>
@@ -1551,7 +1553,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1596,7 +1599,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/5.1/about/migration.html
+++ b/5.1/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/5.1/about/versioning.html
+++ b/5.1/about/versioning.html
@@ -125,9 +125,11 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org">Semantic Versioning</a>.</p>
 <p>It is recommended that you add Karma by running:</p>
-<pre><code class="language-bash">$ yarn add --dev karma</code></pre>
+<pre><code class="language-bash">$ yarn add --dev karma
+</code></pre>
 <p>or: </p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/5.1/config/browsers.html
+++ b/5.1/config/browsers.html
@@ -124,7 +124,8 @@
       </div>
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time-consuming task. However, Karma can automate this for you. Simply add the browsers you would like to capture into the <a href="configuration-file.html">configuration file</a>.</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them after the job is over.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -142,13 +143,15 @@
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then, inside your configuration file, add the browser name in <code>browsers</code> array.</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also, keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -161,7 +164,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can also be configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -173,7 +177,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. Here is a code snippet example explaining how to set a display name for a custom launcher.</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -182,7 +187,8 @@ user agent. Here is a code snippet example explaining how to set a display name 
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>If the definition is as above, the browser will be displayed as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -195,17 +201,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID-parameter to be used to connect to the server. The supplied ID is used by the server to keep track of which specific browser is captured.</p>
 
         </div>

--- a/5.1/config/configuration-file.html
+++ b/5.1/config/configuration-file.html
@@ -148,13 +148,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <pre><code class="language-typescript"><span class="hljs-comment">// karma.conf.ts</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
   config.set({
@@ -162,7 +164,8 @@ which accepts one argument: the configuration object.</p>
     frameworks: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-}</code></pre>
+}
+</code></pre>
 <h3>Customized TypeScript Configuration</h3>
 <p>Under the hood Karma uses ts-node to transpile TypeScript to JavaScript. If the resolved <code>tsconfig.json</code> has <code>module</code> configured as <code>ES</code> formats. You might get errors like <code>SyntaxError: Unexpected token</code>. This is due that in Node <code>ES</code> module formats are not supported. To overcome this issue you need to configure ts-node to use <code>commonjs</code> module format.</p>
 <p>Create a JavaScript configuration file that overrides the module format.</p>
@@ -172,7 +175,8 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">module</span>: <span class="hljs-string">'commonjs'</span>
   }
 });
-<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);</code></pre>
+<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -226,7 +230,8 @@ properties, all of which are optional:</p>
   <span class="hljs-attr">format</span>: string,
   <span class="hljs-attr">path</span>:   string,
   <span class="hljs-attr">terminal</span>: boolean
-}</code></pre>
+}
+</code></pre>
 <p>Here the <code>level</code> is the desired log-level, where level <code>log</code> always is logged. The format
 is a string where <code>%b</code>, <code>%t</code>, <code>%T</code>, and <code>%m</code> are replaced with the browser string,
 log type in lower-case, log type in uppercase, and log message, respectively. This format will
@@ -351,7 +356,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>detached</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>false</code></p>
@@ -411,7 +417,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -441,12 +448,14 @@ Use this to prevent accidental disabling tests needed to validate production.</p
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -456,7 +465,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>beforeMiddleware</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -527,7 +537,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>
@@ -597,7 +608,8 @@ between browsers and the testing server).</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-javascript">proxyReq: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">proxyReq, req, res, options</span>) </span>{
   proxyReq.setHeader(<span class="hljs-string">'Referer'</span>, <span class="hljs-string">'https://www.example.com/'</span>);
-}</code></pre>
+}
+</code></pre>
 <h2>proxyRes</h2>
 <p><strong>Type:</strong> Function</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -610,7 +622,8 @@ between browsers and the testing server).</p>
       <span class="hljs-keyword">return</span> cookie.replace(<span class="hljs-regexp">/\s*secure;?/i</span>, <span class="hljs-string">''</span>);
     })
   }
-}</code></pre>
+}
+</code></pre>
 <h2>upstreamProxy</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -652,7 +665,8 @@ Trying to start ChromeHeadless again (<span class="hljs-number">1</span>/<span c
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
 Trying to start ChromeHeadless again (<span class="hljs-number">2</span>/<span class="hljs-number">2</span>).
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
-ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.</code></pre>
+ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.
+</code></pre>
 <p>If you see this error, you can try increasing the socket connection timeout.</p>
 
         </div>

--- a/5.1/config/files.html
+++ b/5.1/config/files.html
@@ -227,26 +227,30 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading Assets</h2>
 <p>By default all assets are served at <code>http://localhost:[PORT]/base/</code></p>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However, they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition, you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <h2>Webserver features</h2>
 <ul>
 <li><a href="https://en.wikipedia.org/wiki/Byte_serving">Range requests</a>.</li>

--- a/5.1/config/plugins.html
+++ b/5.1/config/plugins.html
@@ -134,9 +134,11 @@ In fact, all the existing preprocessors, reporters, browser launchers and framew
     <span class="hljs-string">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-string">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads all sibling NPM modules which have a name starting with <code>karma-*</code>.</p>
 <p>You can also explicitly list plugins you want to load via the <code>plugins</code> configuration setting. The configuration value can either be
@@ -149,7 +151,8 @@ a string (module name), which will be required by Karma, or an object (inlined p
   <span class="hljs-comment">// inlined plugins</span>
   {<span class="hljs-string">'framework:xyz'</span>: [<span class="hljs-string">'factory'</span>, factoryFn]},
   <span class="hljs-built_in">require</span>(<span class="hljs-string">'./plugin-required-from-config'</span>)
-]</code></pre>
+]
+</code></pre>
 <p>There are already many <a href="https://npmjs.org/browse/keyword/karma-plugin">existing plugins</a>. Of course, you can write <a href="../dev/plugins.html">your own plugins</a> too!</p>
 
         </div>

--- a/5.1/config/preprocessors.html
+++ b/5.1/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can also be configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Mini matching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>
@@ -190,7 +195,8 @@ will execute the preprocessors over that file in the order they are listed in
 the corresponding array. So for instance, if the config object is:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then karma will execute <code>&#39;a&#39;</code> before executing <code>&#39;b&#39;</code>.</p>
 <p>If a file matches multiple keys, karma will use the <code>config.preprocessor_priority</code>
 map to set the order. If this config option is not set, karma do its best to
@@ -198,18 +204,21 @@ execute the preprocessors in a reasonable order.  So if you have:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then for <code>a.js</code>, karma will run <code>&#39;a&#39;</code> then <code>&#39;b&#39;</code> then <code>&#39;c&#39;</code>.  If two lists contradict each other, like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then karma will arbitrarily pick one list to prioritize over the other.  In a
 case like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'c'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'d'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then <code>&#39;a&#39;</code> will definitely be run first, <code>&#39;d&#39;</code> will definitely be run last, but
 it&#39;s arbitrary if karma will run <code>&#39;b&#39;</code> before <code>&#39;c&#39;</code> or vice versa.</p>
 

--- a/5.1/dev/git-commit-msg.html
+++ b/5.1/dev/git-commit-msg.html
@@ -133,14 +133,16 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Example commit message:</h2>
 <pre><code class="language-bash">fix(middleware): ensure Range headers adhere more closely to RFC 2616
 
 Add one new dependency, use `range-parser` (Express dependency) to compute
 range. It is more well-tested <span class="hljs-keyword">in</span> the wild.
 
-Fixes <span class="hljs-comment">#2310</span></code></pre>
+Fixes <span class="hljs-comment">#2310</span>
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>The first line cannot be longer than 70 characters, the second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -181,9 +183,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in the case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -193,7 +197,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/5.1/dev/making-changes.html
+++ b/5.1/dev/making-changes.html
@@ -140,7 +140,8 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 
@@ -148,7 +149,8 @@ $ npm run init
 <span class="hljs-comment"># or if you're on Windows</span>
 $ npm run init:windows
 
-$ npm run build</code></pre>
+$ npm run build
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -158,15 +160,18 @@ $ npm run build</code></pre>
 <span class="hljs-comment"># or you can run test suits individually</span>
 $ npm run <span class="hljs-built_in">test</span>:unit
 $ npm run <span class="hljs-built_in">test</span>:e2e
-$ npm run <span class="hljs-built_in">test</span>:client</code></pre>
+$ npm run <span class="hljs-built_in">test</span>:client
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
 <pre><code class="language-bash">$ npm run lint
 <span class="hljs-comment"># or you can also apply auto-fixes where possible</span>
-$ npm run lint:fix</code></pre>
+$ npm run lint:fix
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
-<pre><code class="language-bash">$ npm run build</code></pre>
+<pre><code class="language-bash">$ npm run build
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -174,7 +179,8 @@ $ npm run lint:fix</code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -184,9 +190,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/5.1/dev/plugins.html
+++ b/5.1/dev/plugins.html
@@ -194,7 +194,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 
         </div>
       </div>

--- a/5.1/dev/public-api.html
+++ b/5.1/dev/public-api.html
@@ -132,22 +132,27 @@ You can, however, call Karma programmatically from your node module. Here is the
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(karmaConfig, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p>Notice the capital &#39;S&#39; on  <code>require(&#39;karma&#39;).Server</code>.</p>
 <h3><strong>server.start()</strong></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><strong>server.refreshFiles()</strong></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3><strong>server.refreshFile(path)</strong></h3>
 <p>Trigger a file refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)</code></pre>
+<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>listening</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -209,13 +214,15 @@ You can, however, call Karma programmatically from your node module. Here is the
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p><code>runner.run()</code> returns an <code>EventEmitter</code> which emits a <code>progress</code> event passing
 the reporter output as a <code>Buffer</code> object.</p>
 <p>You may listen for that event to print the reporter output to the console:</p>
 <pre><code class="language-javascript">runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}).on(<span class="hljs-string">'progress'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">data</span>) </span>{
   process.stdout.write(data)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.stopper</h2>
 <h3><strong>stopper.stop(options, [callback=process.exit])</strong></h3>
 <p>This function will signal a running server to stop.  The equivalent of <code>karma stop</code>.  </p>
@@ -225,7 +232,8 @@ stopper.stop({<span class="hljs-attr">port</span>: <span class="hljs-number">987
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Server stop as initiated'</span>)
   }
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.config.parseConfig([configFilePath], [cliOptions])</h2>
 <p>This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
@@ -234,7 +242,8 @@ uses this to load your karma configuration and use that in the stryker configura
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> cfg = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>).config;
 <span class="hljs-keyword">const</span> path = <span class="hljs-built_in">require</span>(<span class="hljs-string">'path'</span>);
 <span class="hljs-comment">// Read karma.conf.js, but override port with 1337</span>
-<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );</code></pre>
+<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );
+</code></pre>
 <h2>karma.constants</h2>
 <h3><strong>constants.VERSION</strong></h3>
 <p>The current version of karma</p>

--- a/5.1/intro/configuration.html
+++ b/5.1/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy-paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/5.1/intro/installation.html
+++ b/5.1/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/5.1/plus/cloud9.html
+++ b/5.1/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript and uses NodeJS on the back-end.</p>
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/5.1/plus/codio.html
+++ b/5.1/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from the right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from the right button).</p>

--- a/5.1/plus/emberjs.html
+++ b/5.1/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/5.1/plus/jenkins.html
+++ b/5.1/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -160,7 +161,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/5.1/plus/requirejs.html
+++ b/5.1/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks work just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -268,7 +272,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -295,14 +300,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/5.1/plus/semaphore.html
+++ b/5.1/plus/semaphore.html
@@ -133,26 +133,29 @@ you already have a Semaphore account.</p>
 create one now. This will both document your configuration and
 make it easy to run your tests. Here&#39;s an example:</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.10"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.10&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
-<pre><code class="language-json">"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers Firefox"
-}</code></pre>
+<pre><code class="language-json">&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers Firefox&quot;
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it on a virtual screen
 during your builds.</p>

--- a/5.1/plus/teamcity.html
+++ b/5.1/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during the build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to the build configuration: use Command Line runner and fill in <code>Custom script</code> text area. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> at the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/5.1/plus/travis.html
+++ b/5.1/plus/travis.html
@@ -135,19 +135,21 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root, create one now. Travis runs <code>npm test</code> to trigger your tests, so this
 is where you tell Travis how to run your tests.</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.12"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.12&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite, so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -160,17 +162,20 @@ like this (if you&#39;re using Xenial):</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">dist:</span> xenial
 <span class="hljs-symbol">services:</span>
-  - xvfb</code></pre>
+  - xvfb
+</code></pre>
 <p>Or this, for Trusty and below:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/5.2/about/changelog.html
+++ b/5.2/about/changelog.html
@@ -946,11 +946,13 @@ to match this new format.</p>
 <ul>
 <li><p>The public api interface has changed to a constructor form. To upgrade change</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 <p>to</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 <p>Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</p>
 </li>
@@ -1580,7 +1582,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1625,7 +1628,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/5.2/about/migration.html
+++ b/5.2/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/5.2/about/versioning.html
+++ b/5.2/about/versioning.html
@@ -125,9 +125,11 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org">Semantic Versioning</a>.</p>
 <p>It is recommended that you add Karma by running:</p>
-<pre><code class="language-bash">$ yarn add --dev karma</code></pre>
+<pre><code class="language-bash">$ yarn add --dev karma
+</code></pre>
 <p>or: </p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/5.2/config/browsers.html
+++ b/5.2/config/browsers.html
@@ -124,7 +124,8 @@
       </div>
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time-consuming task. However, Karma can automate this for you. Simply add the browsers you would like to capture into the <a href="configuration-file.html">configuration file</a>.</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them after the job is over.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -142,13 +143,15 @@
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then, inside your configuration file, add the browser name in <code>browsers</code> array.</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also, keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -161,7 +164,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can also be configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -173,7 +177,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. Here is a code snippet example explaining how to set a display name for a custom launcher.</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -182,7 +187,8 @@ user agent. Here is a code snippet example explaining how to set a display name 
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>If the definition is as above, the browser will be displayed as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -195,17 +201,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID-parameter to be used to connect to the server. The supplied ID is used by the server to keep track of which specific browser is captured.</p>
 
         </div>

--- a/5.2/config/configuration-file.html
+++ b/5.2/config/configuration-file.html
@@ -148,13 +148,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <pre><code class="language-typescript"><span class="hljs-comment">// karma.conf.ts</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
   config.set({
@@ -162,7 +164,8 @@ which accepts one argument: the configuration object.</p>
     frameworks: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-}</code></pre>
+}
+</code></pre>
 <h3>Customized TypeScript Configuration</h3>
 <p>Under the hood Karma uses ts-node to transpile TypeScript to JavaScript. If the resolved <code>tsconfig.json</code> has <code>module</code> configured as <code>ES</code> formats. You might get errors like <code>SyntaxError: Unexpected token</code>. This is due that in Node <code>ES</code> module formats are not supported. To overcome this issue you need to configure ts-node to use <code>commonjs</code> module format.</p>
 <p>Create a JavaScript configuration file that overrides the module format.</p>
@@ -172,7 +175,8 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">module</span>: <span class="hljs-string">'commonjs'</span>
   }
 });
-<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);</code></pre>
+<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -226,7 +230,8 @@ properties, all of which are optional:</p>
   <span class="hljs-attr">format</span>: string,
   <span class="hljs-attr">path</span>:   string,
   <span class="hljs-attr">terminal</span>: boolean
-}</code></pre>
+}
+</code></pre>
 <p>Here the <code>level</code> is the desired log-level, where level <code>log</code> always is logged. The format
 is a string where <code>%b</code>, <code>%t</code>, <code>%T</code>, and <code>%m</code> are replaced with the browser string,
 log type in lower-case, log type in uppercase, and log message, respectively. This format will
@@ -351,7 +356,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>detached</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>false</code></p>
@@ -411,7 +417,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -441,12 +448,14 @@ Use this to prevent accidental disabling tests needed to validate production.</p
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -456,7 +465,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>beforeMiddleware</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -527,7 +537,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>
@@ -597,7 +608,8 @@ between browsers and the testing server).</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-javascript">proxyReq: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">proxyReq, req, res, options</span>) </span>{
   proxyReq.setHeader(<span class="hljs-string">'Referer'</span>, <span class="hljs-string">'https://www.example.com/'</span>);
-}</code></pre>
+}
+</code></pre>
 <h2>proxyRes</h2>
 <p><strong>Type:</strong> Function</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -610,7 +622,8 @@ between browsers and the testing server).</p>
       <span class="hljs-keyword">return</span> cookie.replace(<span class="hljs-regexp">/\s*secure;?/i</span>, <span class="hljs-string">''</span>);
     })
   }
-}</code></pre>
+}
+</code></pre>
 <h2>upstreamProxy</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -652,7 +665,8 @@ Trying to start ChromeHeadless again (<span class="hljs-number">1</span>/<span c
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
 Trying to start ChromeHeadless again (<span class="hljs-number">2</span>/<span class="hljs-number">2</span>).
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
-ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.</code></pre>
+ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.
+</code></pre>
 <p>If you see this error, you can try increasing the socket connection timeout.</p>
 
         </div>

--- a/5.2/config/files.html
+++ b/5.2/config/files.html
@@ -224,26 +224,30 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading Assets</h2>
 <p>By default all assets are served at <code>http://localhost:[PORT]/base/</code></p>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However, they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition, you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <h2>Webserver features</h2>
 <ul>
 <li><a href="https://en.wikipedia.org/wiki/Byte_serving">Range requests</a>.</li>

--- a/5.2/config/plugins.html
+++ b/5.2/config/plugins.html
@@ -134,9 +134,11 @@ In fact, all the existing preprocessors, reporters, browser launchers and framew
     <span class="hljs-string">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-string">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads all sibling NPM modules which have a name starting with <code>karma-*</code>.</p>
 <p>You can also explicitly list plugins you want to load via the <code>plugins</code> configuration setting. The configuration value can either be
@@ -149,7 +151,8 @@ a string (module name), which will be required by Karma, or an object (inlined p
   <span class="hljs-comment">// inlined plugins</span>
   {<span class="hljs-string">'framework:xyz'</span>: [<span class="hljs-string">'factory'</span>, factoryFn]},
   <span class="hljs-built_in">require</span>(<span class="hljs-string">'./plugin-required-from-config'</span>)
-]</code></pre>
+]
+</code></pre>
 <p>There are already many <a href="https://npmjs.org/browse/keyword/karma-plugin">existing plugins</a>. Of course, you can write <a href="../dev/plugins.html">your own plugins</a> too!</p>
 
         </div>

--- a/5.2/config/preprocessors.html
+++ b/5.2/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can also be configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Mini matching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>
@@ -190,7 +195,8 @@ will execute the preprocessors over that file in the order they are listed in
 the corresponding array. So for instance, if the config object is:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then karma will execute <code>&#39;a&#39;</code> before executing <code>&#39;b&#39;</code>.</p>
 <p>If a file matches multiple keys, karma will use the <code>config.preprocessor_priority</code>
 map to set the order. If this config option is not set, karma do its best to
@@ -198,18 +204,21 @@ execute the preprocessors in a reasonable order.  So if you have:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then for <code>a.js</code>, karma will run <code>&#39;a&#39;</code> then <code>&#39;b&#39;</code> then <code>&#39;c&#39;</code>.  If two lists contradict each other, like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then karma will arbitrarily pick one list to prioritize over the other.  In a
 case like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'c'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'d'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then <code>&#39;a&#39;</code> will definitely be run first, <code>&#39;d&#39;</code> will definitely be run last, but
 it&#39;s arbitrary if karma will run <code>&#39;b&#39;</code> before <code>&#39;c&#39;</code> or vice versa.</p>
 

--- a/5.2/dev/git-commit-msg.html
+++ b/5.2/dev/git-commit-msg.html
@@ -133,14 +133,16 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Example commit message:</h2>
 <pre><code class="language-bash">fix(middleware): ensure Range headers adhere more closely to RFC 2616
 
 Add one new dependency, use `range-parser` (Express dependency) to compute
 range. It is more well-tested <span class="hljs-keyword">in</span> the wild.
 
-Fixes <span class="hljs-comment">#2310</span></code></pre>
+Fixes <span class="hljs-comment">#2310</span>
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>The first line cannot be longer than 70 characters, the second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -181,9 +183,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in the case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -193,7 +197,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/5.2/dev/making-changes.html
+++ b/5.2/dev/making-changes.html
@@ -140,13 +140,15 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 
 $ npm run init
 <span class="hljs-comment"># or if you're on Windows</span>
-$ npm run init:windows</code></pre>
+$ npm run init:windows
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -156,15 +158,18 @@ $ npm run init:windows</code></pre>
 <span class="hljs-comment"># or you can run test suits individually</span>
 $ npm run <span class="hljs-built_in">test</span>:unit
 $ npm run <span class="hljs-built_in">test</span>:e2e
-$ npm run <span class="hljs-built_in">test</span>:client</code></pre>
+$ npm run <span class="hljs-built_in">test</span>:client
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
 <pre><code class="language-bash">$ npm run lint
 <span class="hljs-comment"># or you can also apply auto-fixes where possible</span>
-$ npm run lint:fix</code></pre>
+$ npm run lint:fix
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
-<pre><code class="language-bash">$ npm run build</code></pre>
+<pre><code class="language-bash">$ npm run build
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -172,7 +177,8 @@ $ npm run lint:fix</code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -182,9 +188,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/5.2/dev/plugins.html
+++ b/5.2/dev/plugins.html
@@ -194,7 +194,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 
         </div>
       </div>

--- a/5.2/dev/public-api.html
+++ b/5.2/dev/public-api.html
@@ -132,22 +132,27 @@ You can, however, call Karma programmatically from your node module. Here is the
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(karmaConfig, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p>Notice the capital &#39;S&#39; on  <code>require(&#39;karma&#39;).Server</code>.</p>
 <h3><strong>server.start()</strong></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><strong>server.refreshFiles()</strong></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3><strong>server.refreshFile(path)</strong></h3>
 <p>Trigger a file refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)</code></pre>
+<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>listening</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -209,13 +214,15 @@ You can, however, call Karma programmatically from your node module. Here is the
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p><code>runner.run()</code> returns an <code>EventEmitter</code> which emits a <code>progress</code> event passing
 the reporter output as a <code>Buffer</code> object.</p>
 <p>You may listen for that event to print the reporter output to the console:</p>
 <pre><code class="language-javascript">runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}).on(<span class="hljs-string">'progress'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">data</span>) </span>{
   process.stdout.write(data)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.stopper</h2>
 <h3><strong>stopper.stop(options, [callback=process.exit])</strong></h3>
 <p>This function will signal a running server to stop.  The equivalent of <code>karma stop</code>.  </p>
@@ -225,7 +232,8 @@ stopper.stop({<span class="hljs-attr">port</span>: <span class="hljs-number">987
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Server stop as initiated'</span>)
   }
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.config.parseConfig([configFilePath], [cliOptions])</h2>
 <p>This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
@@ -234,7 +242,8 @@ uses this to load your karma configuration and use that in the stryker configura
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> cfg = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>).config;
 <span class="hljs-keyword">const</span> path = <span class="hljs-built_in">require</span>(<span class="hljs-string">'path'</span>);
 <span class="hljs-comment">// Read karma.conf.js, but override port with 1337</span>
-<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );</code></pre>
+<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );
+</code></pre>
 <h2>karma.constants</h2>
 <h3><strong>constants.VERSION</strong></h3>
 <p>The current version of karma</p>

--- a/5.2/intro/configuration.html
+++ b/5.2/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy-paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/5.2/intro/installation.html
+++ b/5.2/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/5.2/plus/cloud9.html
+++ b/5.2/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript and uses NodeJS on the back-end.</p>
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/5.2/plus/codio.html
+++ b/5.2/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from the right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from the right button).</p>

--- a/5.2/plus/emberjs.html
+++ b/5.2/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/5.2/plus/jenkins.html
+++ b/5.2/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -160,7 +161,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/5.2/plus/requirejs.html
+++ b/5.2/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks work just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -268,7 +272,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -295,14 +300,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/5.2/plus/semaphore.html
+++ b/5.2/plus/semaphore.html
@@ -133,26 +133,29 @@ you already have a Semaphore account.</p>
 create one now. This will both document your configuration and
 make it easy to run your tests. Here&#39;s an example:</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.10"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.10&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
-<pre><code class="language-json">"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers Firefox"
-}</code></pre>
+<pre><code class="language-json">&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers Firefox&quot;
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it on a virtual screen
 during your builds.</p>

--- a/5.2/plus/teamcity.html
+++ b/5.2/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during the build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to the build configuration: use Command Line runner and fill in <code>Custom script</code> text area. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> at the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/5.2/plus/travis.html
+++ b/5.2/plus/travis.html
@@ -135,19 +135,21 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root, create one now. Travis runs <code>npm test</code> to trigger your tests, so this
 is where you tell Travis how to run your tests.</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.12"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.12&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite, so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -160,17 +162,20 @@ like this (if you&#39;re using Xenial):</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">dist:</span> xenial
 <span class="hljs-symbol">services:</span>
-  - xvfb</code></pre>
+  - xvfb
+</code></pre>
 <p>Or this, for Trusty and below:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/6.0/about/changelog.html
+++ b/6.0/about/changelog.html
@@ -174,7 +174,8 @@
 </ul>
 <pre><code>const {<span class="hljs-built_in"> Server </span>} = require(<span class="hljs-string">'karma'</span>);
 const<span class="hljs-built_in"> server </span>= new Server();
-server.start();</code></pre>
+server.start();
+</code></pre>
 <ul>
 <li><strong>cli:</strong> Karma is more strict and will error out if unknown option or argument is passed to CLI.</li>
 <li>Using Karma to run Dart code in the browser is no longer supported. Use your favorite Dart-to-JS compiler instead.</li>
@@ -1008,11 +1009,13 @@ to match this new format.</p>
 <ul>
 <li><p>The public api interface has changed to a constructor form. To upgrade change</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 <p>to</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 <p>Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</p>
 </li>
@@ -1642,7 +1645,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1687,7 +1691,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/6.0/about/migration.html
+++ b/6.0/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/6.0/about/versioning.html
+++ b/6.0/about/versioning.html
@@ -125,9 +125,11 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org">Semantic Versioning</a>.</p>
 <p>It is recommended that you add Karma by running:</p>
-<pre><code class="language-bash">$ yarn add --dev karma</code></pre>
+<pre><code class="language-bash">$ yarn add --dev karma
+</code></pre>
 <p>or: </p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/6.0/config/browsers.html
+++ b/6.0/config/browsers.html
@@ -124,7 +124,8 @@
       </div>
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time-consuming task. However, Karma can automate this for you. Simply add the browsers you would like to capture into the <a href="configuration-file.html">configuration file</a>.</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them after the job is over.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -142,13 +143,15 @@
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then, inside your configuration file, add the browser name in <code>browsers</code> array.</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also, keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -161,7 +164,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can also be configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -173,7 +177,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. Here is a code snippet example explaining how to set a display name for a custom launcher.</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -182,7 +187,8 @@ user agent. Here is a code snippet example explaining how to set a display name 
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>If the definition is as above, the browser will be displayed as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -195,17 +201,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID-parameter to be used to connect to the server. The supplied ID is used by the server to keep track of which specific browser is captured.</p>
 
         </div>

--- a/6.0/config/configuration-file.html
+++ b/6.0/config/configuration-file.html
@@ -148,13 +148,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <pre><code class="language-typescript"><span class="hljs-comment">// karma.conf.ts</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
   config.set({
@@ -162,7 +164,8 @@ which accepts one argument: the configuration object.</p>
     frameworks: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-}</code></pre>
+}
+</code></pre>
 <h3>Customized TypeScript Configuration</h3>
 <p>Under the hood Karma uses ts-node to transpile TypeScript to JavaScript. If the resolved <code>tsconfig.json</code> has <code>module</code> configured as <code>ES</code> formats. You might get errors like <code>SyntaxError: Unexpected token</code>. This is due that in Node <code>ES</code> module formats are not supported. To overcome this issue you need to configure ts-node to use <code>commonjs</code> module format.</p>
 <p>Create a JavaScript configuration file that overrides the module format.</p>
@@ -172,7 +175,8 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">module</span>: <span class="hljs-string">'commonjs'</span>
   }
 });
-<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);</code></pre>
+<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -226,7 +230,8 @@ properties, all of which are optional:</p>
   <span class="hljs-attr">format</span>: string,
   <span class="hljs-attr">path</span>:   string,
   <span class="hljs-attr">terminal</span>: boolean
-}</code></pre>
+}
+</code></pre>
 <p>Here the <code>level</code> is the desired log-level, where level <code>log</code> always is logged. The format
 is a string where <code>%b</code>, <code>%t</code>, <code>%T</code>, and <code>%m</code> are replaced with the browser string,
 log type in lower-case, log type in uppercase, and log message, respectively. This format will
@@ -351,7 +356,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>detached</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>false</code></p>
@@ -411,7 +417,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -441,12 +448,14 @@ Use this to prevent accidental disabling tests needed to validate production.</p
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -456,7 +465,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>beforeMiddleware</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -527,7 +537,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>
@@ -597,7 +608,8 @@ between browsers and the testing server).</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-javascript">proxyReq: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">proxyReq, req, res, options</span>) </span>{
   proxyReq.setHeader(<span class="hljs-string">'Referer'</span>, <span class="hljs-string">'https://www.example.com/'</span>);
-}</code></pre>
+}
+</code></pre>
 <h2>proxyRes</h2>
 <p><strong>Type:</strong> Function</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -610,7 +622,8 @@ between browsers and the testing server).</p>
       <span class="hljs-keyword">return</span> cookie.replace(<span class="hljs-regexp">/\s*secure;?/i</span>, <span class="hljs-string">''</span>);
     })
   }
-}</code></pre>
+}
+</code></pre>
 <h2>upstreamProxy</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -652,7 +665,8 @@ Trying to start ChromeHeadless again (<span class="hljs-number">1</span>/<span c
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
 Trying to start ChromeHeadless again (<span class="hljs-number">2</span>/<span class="hljs-number">2</span>).
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
-ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.</code></pre>
+ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.
+</code></pre>
 <p>If you see this error, you can try increasing the socket connection timeout.</p>
 
         </div>

--- a/6.0/config/files.html
+++ b/6.0/config/files.html
@@ -225,7 +225,8 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading files from another server</h2>
 <p>Pattern can also be an absolute URL. This allows including files which are not served by Karma.</p>
 <p>Example:</p>
@@ -234,7 +235,8 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
     <span class="hljs-string">'https://example.com/my-lib.js'</span>,
     { <span class="hljs-attr">pattern</span>: <span class="hljs-string">'https://example.com/my-lib'</span>, <span class="hljs-attr">type</span>: <span class="hljs-string">'js'</span> }
   ]
-})</code></pre>
+})
+</code></pre>
 <p>Absolute URLs have some special rules comparing to the regular file paths:</p>
 <ul>
 <li>Globing is not support, so each URL must be specified as a separate pattern.</li>
@@ -251,20 +253,23 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However, they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition, you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <h2>Webserver features</h2>
 <ul>
 <li><a href="https://en.wikipedia.org/wiki/Byte_serving">Range requests</a>.</li>

--- a/6.0/config/plugins.html
+++ b/6.0/config/plugins.html
@@ -134,9 +134,11 @@ In fact, all the existing preprocessors, reporters, browser launchers and framew
     <span class="hljs-string">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-string">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads all sibling NPM modules which have a name starting with <code>karma-*</code>.</p>
 <p>You can also explicitly list plugins you want to load via the <code>plugins</code> configuration setting. The configuration value can either be
@@ -149,7 +151,8 @@ a string (module name), which will be required by Karma, or an object (inlined p
   <span class="hljs-comment">// inlined plugins</span>
   {<span class="hljs-string">'framework:xyz'</span>: [<span class="hljs-string">'factory'</span>, factoryFn]},
   <span class="hljs-built_in">require</span>(<span class="hljs-string">'./plugin-required-from-config'</span>)
-]</code></pre>
+]
+</code></pre>
 <p>There are already many <a href="https://npmjs.org/browse/keyword/karma-plugin">existing plugins</a>. Of course, you can write <a href="../dev/plugins.html">your own plugins</a> too!</p>
 
         </div>

--- a/6.0/config/preprocessors.html
+++ b/6.0/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can also be configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Mini matching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>
@@ -190,7 +195,8 @@ will execute the preprocessors over that file in the order they are listed in
 the corresponding array. So for instance, if the config object is:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then karma will execute <code>&#39;a&#39;</code> before executing <code>&#39;b&#39;</code>.</p>
 <p>If a file matches multiple keys, karma will use the <code>config.preprocessor_priority</code>
 map to set the order. If this config option is not set, karma do its best to
@@ -198,18 +204,21 @@ execute the preprocessors in a reasonable order.  So if you have:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then for <code>a.js</code>, karma will run <code>&#39;a&#39;</code> then <code>&#39;b&#39;</code> then <code>&#39;c&#39;</code>.  If two lists contradict each other, like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then karma will arbitrarily pick one list to prioritize over the other.  In a
 case like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'c'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'d'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then <code>&#39;a&#39;</code> will definitely be run first, <code>&#39;d&#39;</code> will definitely be run last, but
 it&#39;s arbitrary if karma will run <code>&#39;b&#39;</code> before <code>&#39;c&#39;</code> or vice versa.</p>
 

--- a/6.0/dev/git-commit-msg.html
+++ b/6.0/dev/git-commit-msg.html
@@ -133,14 +133,16 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Example commit message:</h2>
 <pre><code class="language-bash">fix(middleware): ensure Range headers adhere more closely to RFC 2616
 
 Add one new dependency, use `range-parser` (Express dependency) to compute
 range. It is more well-tested <span class="hljs-keyword">in</span> the wild.
 
-Fixes <span class="hljs-comment">#2310</span></code></pre>
+Fixes <span class="hljs-comment">#2310</span>
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>The first line cannot be longer than 70 characters, the second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -181,9 +183,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in the case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -193,7 +197,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/6.0/dev/making-changes.html
+++ b/6.0/dev/making-changes.html
@@ -140,13 +140,15 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 
 $ npm run init
 <span class="hljs-comment"># or if you're on Windows</span>
-$ npm run init:windows</code></pre>
+$ npm run init:windows
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -156,17 +158,20 @@ $ npm run init:windows</code></pre>
 <span class="hljs-comment"># or you can run test suits individually</span>
 $ npm run <span class="hljs-built_in">test</span>:unit
 $ npm run <span class="hljs-built_in">test</span>:e2e
-$ npm run <span class="hljs-built_in">test</span>:client</code></pre>
+$ npm run <span class="hljs-built_in">test</span>:client
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
 <pre><code class="language-bash">$ npm run lint
 <span class="hljs-comment"># or you can also apply auto-fixes where possible</span>
-$ npm run lint:fix</code></pre>
+$ npm run lint:fix
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
 <pre><code class="language-bash">$ npm run build
 <span class="hljs-comment"># or use the watch mode</span>
-$ npm run build:watch</code></pre>
+$ npm run build:watch
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -174,7 +179,8 @@ $ npm run build:watch</code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -184,9 +190,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/6.0/dev/plugins.html
+++ b/6.0/dev/plugins.html
@@ -194,7 +194,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 
         </div>
       </div>

--- a/6.0/dev/public-api.html
+++ b/6.0/dev/public-api.html
@@ -132,22 +132,27 @@ You can, however, call Karma programmatically from your node module. Here is the
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(karmaConfig, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p>Notice the capital &#39;S&#39; on  <code>require(&#39;karma&#39;).Server</code>.</p>
 <h3><strong>server.start()</strong></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><strong>server.refreshFiles()</strong></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3><strong>server.refreshFile(path)</strong></h3>
 <p>Trigger a file refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)</code></pre>
+<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>listening</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -209,13 +214,15 @@ You can, however, call Karma programmatically from your node module. Here is the
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p><code>runner.run()</code> returns an <code>EventEmitter</code> which emits a <code>progress</code> event passing
 the reporter output as a <code>Buffer</code> object.</p>
 <p>You may listen for that event to print the reporter output to the console:</p>
 <pre><code class="language-javascript">runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}).on(<span class="hljs-string">'progress'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">data</span>) </span>{
   process.stdout.write(data)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.stopper</h2>
 <h3><strong>stopper.stop(options, [callback=process.exit])</strong></h3>
 <p>This function will signal a running server to stop.  The equivalent of <code>karma stop</code>.  </p>
@@ -225,7 +232,8 @@ stopper.stop({<span class="hljs-attr">port</span>: <span class="hljs-number">987
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Server stop as initiated'</span>)
   }
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.config.parseConfig([configFilePath], [cliOptions])</h2>
 <p>This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
@@ -234,7 +242,8 @@ uses this to load your karma configuration and use that in the stryker configura
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> cfg = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>).config;
 <span class="hljs-keyword">const</span> path = <span class="hljs-built_in">require</span>(<span class="hljs-string">'path'</span>);
 <span class="hljs-comment">// Read karma.conf.js, but override port with 1337</span>
-<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );</code></pre>
+<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );
+</code></pre>
 <h2>karma.constants</h2>
 <h3><strong>constants.VERSION</strong></h3>
 <p>The current version of karma</p>

--- a/6.0/intro/configuration.html
+++ b/6.0/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy-paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/6.0/intro/installation.html
+++ b/6.0/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/6.0/plus/cloud9.html
+++ b/6.0/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript and uses NodeJS on the back-end.</p>
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/6.0/plus/codio.html
+++ b/6.0/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from the right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from the right button).</p>

--- a/6.0/plus/emberjs.html
+++ b/6.0/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/6.0/plus/jenkins.html
+++ b/6.0/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -160,7 +161,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/6.0/plus/requirejs.html
+++ b/6.0/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks work just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -268,7 +272,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -295,14 +300,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/6.0/plus/semaphore.html
+++ b/6.0/plus/semaphore.html
@@ -133,26 +133,29 @@ you already have a Semaphore account.</p>
 create one now. This will both document your configuration and
 make it easy to run your tests. Here&#39;s an example:</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.10"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.10&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
-<pre><code class="language-json">"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers Firefox"
-}</code></pre>
+<pre><code class="language-json">&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers Firefox&quot;
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it on a virtual screen
 during your builds.</p>

--- a/6.0/plus/teamcity.html
+++ b/6.0/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during the build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to the build configuration: use Command Line runner and fill in <code>Custom script</code> text area. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> at the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/6.0/plus/travis.html
+++ b/6.0/plus/travis.html
@@ -135,19 +135,21 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root, create one now. Travis runs <code>npm test</code> to trigger your tests, so this
 is where you tell Travis how to run your tests.</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.12"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.12&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite, so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -160,17 +162,20 @@ like this (if you&#39;re using Xenial):</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">dist:</span> xenial
 <span class="hljs-symbol">services:</span>
-  - xvfb</code></pre>
+  - xvfb
+</code></pre>
 <p>Or this, for Trusty and below:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/6.1/about/changelog.html
+++ b/6.1/about/changelog.html
@@ -191,7 +191,8 @@
 </ul>
 <pre><code>const {<span class="hljs-built_in"> Server </span>} = require(<span class="hljs-string">'karma'</span>);
 const<span class="hljs-built_in"> server </span>= new Server();
-server.start();</code></pre>
+server.start();
+</code></pre>
 <ul>
 <li><strong>cli:</strong> Karma is more strict and will error out if unknown option or argument is passed to CLI.</li>
 <li>Using Karma to run Dart code in the browser is no longer supported. Use your favorite Dart-to-JS compiler instead.</li>
@@ -1025,11 +1026,13 @@ to match this new format.</p>
 <ul>
 <li><p>The public api interface has changed to a constructor form. To upgrade change</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 <p>to</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 <p>Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</p>
 </li>
@@ -1659,7 +1662,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1704,7 +1708,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/6.1/about/migration.html
+++ b/6.1/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/6.1/about/versioning.html
+++ b/6.1/about/versioning.html
@@ -125,9 +125,11 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org">Semantic Versioning</a>.</p>
 <p>It is recommended that you add Karma by running:</p>
-<pre><code class="language-bash">$ yarn add --dev karma</code></pre>
+<pre><code class="language-bash">$ yarn add --dev karma
+</code></pre>
 <p>or: </p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/6.1/config/browsers.html
+++ b/6.1/config/browsers.html
@@ -124,7 +124,8 @@
       </div>
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time-consuming task. However, Karma can automate this for you. Simply add the browsers you would like to capture into the <a href="configuration-file.html">configuration file</a>.</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them after the job is over.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -142,13 +143,15 @@
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then, inside your configuration file, add the browser name in <code>browsers</code> array.</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also, keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -161,7 +164,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can also be configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -173,7 +177,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. Here is a code snippet example explaining how to set a display name for a custom launcher.</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -182,7 +187,8 @@ user agent. Here is a code snippet example explaining how to set a display name 
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>If the definition is as above, the browser will be displayed as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -195,17 +201,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID-parameter to be used to connect to the server. The supplied ID is used by the server to keep track of which specific browser is captured.</p>
 
         </div>

--- a/6.1/config/configuration-file.html
+++ b/6.1/config/configuration-file.html
@@ -148,13 +148,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <pre><code class="language-typescript"><span class="hljs-comment">// karma.conf.ts</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
   config.set({
@@ -162,7 +164,8 @@ which accepts one argument: the configuration object.</p>
     frameworks: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-}</code></pre>
+}
+</code></pre>
 <h3>Customized TypeScript Configuration</h3>
 <p>Under the hood Karma uses ts-node to transpile TypeScript to JavaScript. If the resolved <code>tsconfig.json</code> has <code>module</code> configured as <code>ES</code> formats. You might get errors like <code>SyntaxError: Unexpected token</code>. This is due that in Node <code>ES</code> module formats are not supported. To overcome this issue you need to configure ts-node to use <code>commonjs</code> module format.</p>
 <p>Create a JavaScript configuration file that overrides the module format.</p>
@@ -172,7 +175,8 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">module</span>: <span class="hljs-string">'commonjs'</span>
   }
 });
-<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);</code></pre>
+<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -226,7 +230,8 @@ properties, all of which are optional:</p>
   <span class="hljs-attr">format</span>: string,
   <span class="hljs-attr">path</span>:   string,
   <span class="hljs-attr">terminal</span>: boolean
-}</code></pre>
+}
+</code></pre>
 <p>Here the <code>level</code> is the desired log-level, where level <code>log</code> always is logged. The format
 is a string where <code>%b</code>, <code>%t</code>, <code>%T</code>, and <code>%m</code> are replaced with the browser string,
 log type in lower-case, log type in uppercase, and log message, respectively. This format will
@@ -351,7 +356,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>detached</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>false</code></p>
@@ -411,7 +417,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -441,12 +448,14 @@ Use this to prevent accidental disabling tests needed to validate production.</p
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -456,7 +465,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>beforeMiddleware</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -524,7 +534,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>
@@ -594,7 +605,8 @@ between browsers and the testing server).</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-javascript">proxyReq: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">proxyReq, req, res, options</span>) </span>{
   proxyReq.setHeader(<span class="hljs-string">'Referer'</span>, <span class="hljs-string">'https://www.example.com/'</span>);
-}</code></pre>
+}
+</code></pre>
 <h2>proxyRes</h2>
 <p><strong>Type:</strong> Function</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -607,7 +619,8 @@ between browsers and the testing server).</p>
       <span class="hljs-keyword">return</span> cookie.replace(<span class="hljs-regexp">/\s*secure;?/i</span>, <span class="hljs-string">''</span>);
     })
   }
-}</code></pre>
+}
+</code></pre>
 <h2>upstreamProxy</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -649,7 +662,8 @@ Trying to start ChromeHeadless again (<span class="hljs-number">1</span>/<span c
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
 Trying to start ChromeHeadless again (<span class="hljs-number">2</span>/<span class="hljs-number">2</span>).
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
-ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.</code></pre>
+ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.
+</code></pre>
 <p>If you see this error, you can try increasing the socket connection timeout.</p>
 
         </div>

--- a/6.1/config/files.html
+++ b/6.1/config/files.html
@@ -225,7 +225,8 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading files from another server</h2>
 <p>Pattern can also be an absolute URL. This allows including files which are not served by Karma.</p>
 <p>Example:</p>
@@ -234,7 +235,8 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
     <span class="hljs-string">'https://example.com/my-lib.js'</span>,
     { <span class="hljs-attr">pattern</span>: <span class="hljs-string">'https://example.com/my-lib'</span>, <span class="hljs-attr">type</span>: <span class="hljs-string">'js'</span> }
   ]
-})</code></pre>
+})
+</code></pre>
 <p>Absolute URLs have some special rules comparing to the regular file paths:</p>
 <ul>
 <li>Globing is not support, so each URL must be specified as a separate pattern.</li>
@@ -251,20 +253,23 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However, they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition, you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <h2>Webserver features</h2>
 <ul>
 <li><a href="https://en.wikipedia.org/wiki/Byte_serving">Range requests</a>.</li>

--- a/6.1/config/plugins.html
+++ b/6.1/config/plugins.html
@@ -134,9 +134,11 @@
     <span class="hljs-attr">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-attr">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads plugins from all sibling NPM packages which have a name starting with <code>karma-*</code>.</p>
 <p>You can also override this behavior and explicitly list plugins you want to load via the <code>plugins</code> configuration setting:</p>
@@ -156,7 +158,8 @@
     <span class="hljs-string">'karma-chrome-launcher'</span>,
     <span class="hljs-string">'./my-fancy-plugin'</span>
   ]
-})</code></pre>
+})
+</code></pre>
 <h2>Activating Plugins</h2>
 <p>Adding a plugin to the <code>plugins</code> array only makes Karma aware of the plugin, but it does not activate it. Depending on the plugin type you&#39;ll need to add a plugin name into <code>frameworks</code>, <code>reporters</code>, <code>preprocessors</code>, <code>middleware</code> or <code>browsers</code> configuration key to activate it. For the detailed information refer to the corresponding plugin documentation or check out <a href="../dev/plugins.html">Developing plugins</a> guide for more in-depth explanation of how plugins work.</p>
 

--- a/6.1/config/preprocessors.html
+++ b/6.1/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can also be configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Mini matching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>
@@ -190,7 +195,8 @@ will execute the preprocessors over that file in the order they are listed in
 the corresponding array. So for instance, if the config object is:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then karma will execute <code>&#39;a&#39;</code> before executing <code>&#39;b&#39;</code>.</p>
 <p>If a file matches multiple keys, karma will use the <code>config.preprocessor_priority</code>
 map to set the order. If this config option is not set, karma do its best to
@@ -198,18 +204,21 @@ execute the preprocessors in a reasonable order.  So if you have:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then for <code>a.js</code>, karma will run <code>&#39;a&#39;</code> then <code>&#39;b&#39;</code> then <code>&#39;c&#39;</code>.  If two lists contradict each other, like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then karma will arbitrarily pick one list to prioritize over the other.  In a
 case like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'c'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'d'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then <code>&#39;a&#39;</code> will definitely be run first, <code>&#39;d&#39;</code> will definitely be run last, but
 it&#39;s arbitrary if karma will run <code>&#39;b&#39;</code> before <code>&#39;c&#39;</code> or vice versa.</p>
 

--- a/6.1/dev/git-commit-msg.html
+++ b/6.1/dev/git-commit-msg.html
@@ -133,14 +133,16 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Example commit message:</h2>
 <pre><code class="language-bash">fix(middleware): ensure Range headers adhere more closely to RFC 2616
 
 Add one new dependency, use `range-parser` (Express dependency) to compute
 range. It is more well-tested <span class="hljs-keyword">in</span> the wild.
 
-Fixes <span class="hljs-comment">#2310</span></code></pre>
+Fixes <span class="hljs-comment">#2310</span>
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>The first line cannot be longer than 70 characters, the second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -181,9 +183,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in the case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -193,7 +197,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/6.1/dev/making-changes.html
+++ b/6.1/dev/making-changes.html
@@ -140,13 +140,15 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 
 $ npm run init
 <span class="hljs-comment"># or if you're on Windows</span>
-$ npm run init:windows</code></pre>
+$ npm run init:windows
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -156,17 +158,20 @@ $ npm run init:windows</code></pre>
 <span class="hljs-comment"># or you can run test suits individually</span>
 $ npm run <span class="hljs-built_in">test</span>:unit
 $ npm run <span class="hljs-built_in">test</span>:e2e
-$ npm run <span class="hljs-built_in">test</span>:client</code></pre>
+$ npm run <span class="hljs-built_in">test</span>:client
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
 <pre><code class="language-bash">$ npm run lint
 <span class="hljs-comment"># or you can also apply auto-fixes where possible</span>
-$ npm run lint:fix</code></pre>
+$ npm run lint:fix
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
 <pre><code class="language-bash">$ npm run build
 <span class="hljs-comment"># or use the watch mode</span>
-$ npm run build:watch</code></pre>
+$ npm run build:watch
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -174,7 +179,8 @@ $ npm run build:watch</code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -184,9 +190,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/6.1/dev/plugins.html
+++ b/6.1/dev/plugins.html
@@ -157,7 +157,8 @@
   <span class="hljs-comment">// function and use whatever it returns as a service for the DI token</span>
   <span class="hljs-comment">// `framework:hello`.</span>
   <span class="hljs-string">'framework:hello'</span>: [<span class="hljs-string">'factory'</span>, helloFrameworkFactory]
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-js"><span class="hljs-comment">// karma.conf.js</span>
 
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
@@ -169,7 +170,8 @@
     <span class="hljs-comment">// corresponding configuration key.</span>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'hello'</span>]
   })
-}</code></pre>
+}
+</code></pre>
 <h2>Injecting dependencies</h2>
 <p>In &quot;Dependency injection&quot; section we discussed that it is possible to inject any Karma services into a plugin and interact with them. This can be done by setting an <code>$inject</code> property on the plugin&#39;s factory function to an array of DI tokens plugin wishes to interact with. Karma will pick up this property and pass requested services to the factory functions as parameters.</p>
 <p>Let&#39;s make the <code>hello</code> framework a bit more useful and make it add <code>hello.js</code> file to the <code>files</code> array. This way users of the plugin can, for example, access a function defined in <code>hello.js</code> from their tests.</p>
@@ -190,7 +192,8 @@ helloFrameworkFactory.$inject = [<span class="hljs-string">'config'</span>]
 
 <span class="hljs-built_in">module</span>.exports = {
   <span class="hljs-string">'framework:hello'</span>: [<span class="hljs-string">'factory'</span>, helloFrameworkFactory]
-};</code></pre>
+};
+</code></pre>
 <p>The Karma config is unchanged and is omitted for brevity. See above example for the plugin usage.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Currently, Karma uses <a href="https://github.com/vojtajina/node-di">node-di</a> library as a DI implementation. The library is more powerful than what&#39;s documented above, however, the DI implementation may change in the future, so we recommend not to rely on the node-di implementation details.</div>
 <h2>Plugin types</h2>
@@ -230,7 +233,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 <h3>Reporters</h3>
 <ul>
 <li>example plugins: <a href="https://github.com/karma-runner/karma-growl-reporter">karma-growl-reporter</a>, <a href="https://github.com/karma-runner/karma-junit-reporter">karma-junit-reporter</a>, <a href="https://github.com/ameerthehacker/karma-material-reporter">karma-material-reporter</a></li>

--- a/6.1/dev/public-api.html
+++ b/6.1/dev/public-api.html
@@ -132,22 +132,27 @@ You can, however, call Karma programmatically from your node module. Here is the
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(karmaConfig, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p>Notice the capital &#39;S&#39; on  <code>require(&#39;karma&#39;).Server</code>.</p>
 <h3><strong>server.start()</strong></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><strong>server.refreshFiles()</strong></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3><strong>server.refreshFile(path)</strong></h3>
 <p>Trigger a file refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)</code></pre>
+<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>listening</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -209,13 +214,15 @@ You can, however, call Karma programmatically from your node module. Here is the
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p><code>runner.run()</code> returns an <code>EventEmitter</code> which emits a <code>progress</code> event passing
 the reporter output as a <code>Buffer</code> object.</p>
 <p>You may listen for that event to print the reporter output to the console:</p>
 <pre><code class="language-javascript">runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}).on(<span class="hljs-string">'progress'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">data</span>) </span>{
   process.stdout.write(data)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.stopper</h2>
 <h3><strong>stopper.stop(options, [callback=process.exit])</strong></h3>
 <p>This function will signal a running server to stop.  The equivalent of <code>karma stop</code>.  </p>
@@ -225,7 +232,8 @@ stopper.stop({<span class="hljs-attr">port</span>: <span class="hljs-number">987
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Server stop as initiated'</span>)
   }
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.config.parseConfig([configFilePath], [cliOptions])</h2>
 <p>This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
@@ -234,7 +242,8 @@ uses this to load your karma configuration and use that in the stryker configura
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> cfg = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>).config;
 <span class="hljs-keyword">const</span> path = <span class="hljs-built_in">require</span>(<span class="hljs-string">'path'</span>);
 <span class="hljs-comment">// Read karma.conf.js, but override port with 1337</span>
-<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );</code></pre>
+<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );
+</code></pre>
 <h2>karma.constants</h2>
 <h3><strong>constants.VERSION</strong></h3>
 <p>The current version of karma</p>

--- a/6.1/intro/configuration.html
+++ b/6.1/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy-paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/6.1/intro/installation.html
+++ b/6.1/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/6.1/plus/cloud9.html
+++ b/6.1/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript and uses NodeJS on the back-end.</p>
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/6.1/plus/codio.html
+++ b/6.1/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from the right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from the right button).</p>

--- a/6.1/plus/emberjs.html
+++ b/6.1/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/6.1/plus/jenkins.html
+++ b/6.1/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -160,7 +161,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/6.1/plus/requirejs.html
+++ b/6.1/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks work just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -268,7 +272,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -295,14 +300,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/6.1/plus/semaphore.html
+++ b/6.1/plus/semaphore.html
@@ -133,26 +133,29 @@ you already have a Semaphore account.</p>
 create one now. This will both document your configuration and
 make it easy to run your tests. Here&#39;s an example:</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.10"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.10&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
-<pre><code class="language-json">"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers Firefox"
-}</code></pre>
+<pre><code class="language-json">&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers Firefox&quot;
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it on a virtual screen
 during your builds.</p>

--- a/6.1/plus/teamcity.html
+++ b/6.1/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during the build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to the build configuration: use Command Line runner and fill in <code>Custom script</code> text area. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> at the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/6.1/plus/travis.html
+++ b/6.1/plus/travis.html
@@ -135,19 +135,21 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root, create one now. Travis runs <code>npm test</code> to trigger your tests, so this
 is where you tell Travis how to run your tests.</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.12"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.12&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite, so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -160,17 +162,20 @@ like this (if you&#39;re using Xenial):</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">dist:</span> xenial
 <span class="hljs-symbol">services:</span>
-  - xvfb</code></pre>
+  - xvfb
+</code></pre>
 <p>Or this, for Trusty and below:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/6.2/about/changelog.html
+++ b/6.2/about/changelog.html
@@ -196,7 +196,8 @@
 </ul>
 <pre><code>const {<span class="hljs-built_in"> Server </span>} = require(<span class="hljs-string">'karma'</span>);
 const<span class="hljs-built_in"> server </span>= new Server();
-server.start();</code></pre>
+server.start();
+</code></pre>
 <ul>
 <li><strong>cli:</strong> Karma is more strict and will error out if unknown option or argument is passed to CLI.</li>
 <li>Using Karma to run Dart code in the browser is no longer supported. Use your favorite Dart-to-JS compiler instead.</li>
@@ -1030,11 +1031,13 @@ to match this new format.</p>
 <ul>
 <li><p>The public api interface has changed to a constructor form. To upgrade change</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 <p>to</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 <p>Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</p>
 </li>
@@ -1664,7 +1667,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1709,7 +1713,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/6.2/about/migration.html
+++ b/6.2/about/migration.html
@@ -128,7 +128,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -149,9 +150,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/6.2/about/versioning.html
+++ b/6.2/about/versioning.html
@@ -125,9 +125,11 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org">Semantic Versioning</a>.</p>
 <p>It is recommended that you add Karma by running:</p>
-<pre><code class="language-bash">$ yarn add --dev karma</code></pre>
+<pre><code class="language-bash">$ yarn add --dev karma
+</code></pre>
 <p>or: </p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/6.2/config/browsers.html
+++ b/6.2/config/browsers.html
@@ -124,7 +124,8 @@
       </div>
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time-consuming task. However, Karma can automate this for you. Simply add the browsers you would like to capture into the <a href="configuration-file.html">configuration file</a>.</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them after the job is over.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -142,13 +143,15 @@
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then, inside your configuration file, add the browser name in <code>browsers</code> array.</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also, keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -161,7 +164,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can also be configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -173,7 +177,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. Here is a code snippet example explaining how to set a display name for a custom launcher.</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -182,7 +187,8 @@ user agent. Here is a code snippet example explaining how to set a display name 
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>If the definition is as above, the browser will be displayed as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -195,17 +201,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID-parameter to be used to connect to the server. The supplied ID is used by the server to keep track of which specific browser is captured.</p>
 
         </div>

--- a/6.2/config/configuration-file.html
+++ b/6.2/config/configuration-file.html
@@ -148,13 +148,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <pre><code class="language-typescript"><span class="hljs-comment">// karma.conf.ts</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
   config.set({
@@ -162,7 +164,8 @@ which accepts one argument: the configuration object.</p>
     frameworks: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-}</code></pre>
+}
+</code></pre>
 <h3>Customized TypeScript Configuration</h3>
 <p>Under the hood Karma uses ts-node to transpile TypeScript to JavaScript. If the resolved <code>tsconfig.json</code> has <code>module</code> configured as <code>ES</code> formats. You might get errors like <code>SyntaxError: Unexpected token</code>. This is due that in Node <code>ES</code> module formats are not supported. To overcome this issue you need to configure ts-node to use <code>commonjs</code> module format.</p>
 <p>Create a JavaScript configuration file that overrides the module format.</p>
@@ -172,7 +175,8 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">module</span>: <span class="hljs-string">'commonjs'</span>
   }
 });
-<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);</code></pre>
+<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -226,7 +230,8 @@ properties, all of which are optional:</p>
   <span class="hljs-attr">format</span>: string,
   <span class="hljs-attr">path</span>:   string,
   <span class="hljs-attr">terminal</span>: boolean
-}</code></pre>
+}
+</code></pre>
 <p>Here the <code>level</code> is the desired log-level, where level <code>log</code> always is logged. The format
 is a string where <code>%b</code>, <code>%t</code>, <code>%T</code>, and <code>%m</code> are replaced with the browser string,
 log type in lower-case, log type in uppercase, and log message, respectively. This format will
@@ -351,7 +356,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>detached</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>false</code></p>
@@ -411,7 +417,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -441,12 +448,14 @@ Use this to prevent accidental disabling tests needed to validate production.</p
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -456,7 +465,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>beforeMiddleware</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -524,7 +534,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>
@@ -594,7 +605,8 @@ between browsers and the testing server).</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-javascript">proxyReq: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">proxyReq, req, res, options</span>) </span>{
   proxyReq.setHeader(<span class="hljs-string">'Referer'</span>, <span class="hljs-string">'https://www.example.com/'</span>);
-}</code></pre>
+}
+</code></pre>
 <h2>proxyRes</h2>
 <p><strong>Type:</strong> Function</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -607,7 +619,8 @@ between browsers and the testing server).</p>
       <span class="hljs-keyword">return</span> cookie.replace(<span class="hljs-regexp">/\s*secure;?/i</span>, <span class="hljs-string">''</span>);
     })
   }
-}</code></pre>
+}
+</code></pre>
 <h2>upstreamProxy</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -649,7 +662,8 @@ Trying to start ChromeHeadless again (<span class="hljs-number">1</span>/<span c
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
 Trying to start ChromeHeadless again (<span class="hljs-number">2</span>/<span class="hljs-number">2</span>).
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
-ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.</code></pre>
+ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.
+</code></pre>
 <p>If you see this error, you can try increasing the socket connection timeout.</p>
 
         </div>

--- a/6.2/config/files.html
+++ b/6.2/config/files.html
@@ -225,7 +225,8 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading files from another server</h2>
 <p>Pattern can also be an absolute URL. This allows including files which are not served by Karma.</p>
 <p>Example:</p>
@@ -234,7 +235,8 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
     <span class="hljs-string">'https://example.com/my-lib.js'</span>,
     { <span class="hljs-attr">pattern</span>: <span class="hljs-string">'https://example.com/my-lib'</span>, <span class="hljs-attr">type</span>: <span class="hljs-string">'js'</span> }
   ]
-})</code></pre>
+})
+</code></pre>
 <p>Absolute URLs have some special rules comparing to the regular file paths:</p>
 <ul>
 <li>Globing is not support, so each URL must be specified as a separate pattern.</li>
@@ -251,20 +253,23 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However, they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition, you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <h2>Webserver features</h2>
 <ul>
 <li><a href="https://en.wikipedia.org/wiki/Byte_serving">Range requests</a>.</li>

--- a/6.2/config/plugins.html
+++ b/6.2/config/plugins.html
@@ -134,9 +134,11 @@
     <span class="hljs-attr">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-attr">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads plugins from all sibling NPM packages which have a name starting with <code>karma-*</code>.</p>
 <p>You can also override this behavior and explicitly list plugins you want to load via the <code>plugins</code> configuration setting:</p>
@@ -156,7 +158,8 @@
     <span class="hljs-string">'karma-chrome-launcher'</span>,
     <span class="hljs-string">'./my-fancy-plugin'</span>
   ]
-})</code></pre>
+})
+</code></pre>
 <h2>Activating Plugins</h2>
 <p>Adding a plugin to the <code>plugins</code> array only makes Karma aware of the plugin, but it does not activate it. Depending on the plugin type you&#39;ll need to add a plugin name into <code>frameworks</code>, <code>reporters</code>, <code>preprocessors</code>, <code>middleware</code> or <code>browsers</code> configuration key to activate it. For the detailed information refer to the corresponding plugin documentation or check out <a href="../dev/plugins.html">Developing plugins</a> guide for more in-depth explanation of how plugins work.</p>
 

--- a/6.2/config/preprocessors.html
+++ b/6.2/config/preprocessors.html
@@ -130,7 +130,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -148,7 +149,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -156,7 +158,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can also be configured:</p>
@@ -164,14 +167,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Mini matching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>
@@ -190,7 +195,8 @@ will execute the preprocessors over that file in the order they are listed in
 the corresponding array. So for instance, if the config object is:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then karma will execute <code>&#39;a&#39;</code> before executing <code>&#39;b&#39;</code>.</p>
 <p>If a file matches multiple keys, karma will use the <code>config.preprocessor_priority</code>
 map to set the order. If this config option is not set, karma do its best to
@@ -198,18 +204,21 @@ execute the preprocessors in a reasonable order.  So if you have:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then for <code>a.js</code>, karma will run <code>&#39;a&#39;</code> then <code>&#39;b&#39;</code> then <code>&#39;c&#39;</code>.  If two lists contradict each other, like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then karma will arbitrarily pick one list to prioritize over the other.  In a
 case like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'c'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'d'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then <code>&#39;a&#39;</code> will definitely be run first, <code>&#39;d&#39;</code> will definitely be run last, but
 it&#39;s arbitrary if karma will run <code>&#39;b&#39;</code> before <code>&#39;c&#39;</code> or vice versa.</p>
 

--- a/6.2/dev/git-commit-msg.html
+++ b/6.2/dev/git-commit-msg.html
@@ -133,14 +133,16 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Example commit message:</h2>
 <pre><code class="language-bash">fix(middleware): ensure Range headers adhere more closely to RFC 2616
 
 Add one new dependency, use `range-parser` (Express dependency) to compute
 range. It is more well-tested <span class="hljs-keyword">in</span> the wild.
 
-Fixes <span class="hljs-comment">#2310</span></code></pre>
+Fixes <span class="hljs-comment">#2310</span>
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>The first line cannot be longer than 70 characters, the second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -181,9 +183,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in the case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -193,7 +197,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/6.2/dev/making-changes.html
+++ b/6.2/dev/making-changes.html
@@ -140,13 +140,15 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 
 $ npm run init
 <span class="hljs-comment"># or if you're on Windows</span>
-$ npm run init:windows</code></pre>
+$ npm run init:windows
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -156,17 +158,20 @@ $ npm run init:windows</code></pre>
 <span class="hljs-comment"># or you can run test suits individually</span>
 $ npm run <span class="hljs-built_in">test</span>:unit
 $ npm run <span class="hljs-built_in">test</span>:e2e
-$ npm run <span class="hljs-built_in">test</span>:client</code></pre>
+$ npm run <span class="hljs-built_in">test</span>:client
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
 <pre><code class="language-bash">$ npm run lint
 <span class="hljs-comment"># or you can also apply auto-fixes where possible</span>
-$ npm run lint:fix</code></pre>
+$ npm run lint:fix
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
 <pre><code class="language-bash">$ npm run build
 <span class="hljs-comment"># or use the watch mode</span>
-$ npm run build:watch</code></pre>
+$ npm run build:watch
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -174,7 +179,8 @@ $ npm run build:watch</code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -184,9 +190,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/6.2/dev/plugins.html
+++ b/6.2/dev/plugins.html
@@ -157,7 +157,8 @@
   <span class="hljs-comment">// function and use whatever it returns as a service for the DI token</span>
   <span class="hljs-comment">// `framework:hello`.</span>
   <span class="hljs-string">'framework:hello'</span>: [<span class="hljs-string">'factory'</span>, helloFrameworkFactory]
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-js"><span class="hljs-comment">// karma.conf.js</span>
 
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
@@ -169,7 +170,8 @@
     <span class="hljs-comment">// corresponding configuration key.</span>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'hello'</span>]
   })
-}</code></pre>
+}
+</code></pre>
 <h2>Injecting dependencies</h2>
 <p>In &quot;Dependency injection&quot; section we discussed that it is possible to inject any Karma services into a plugin and interact with them. This can be done by setting an <code>$inject</code> property on the plugin&#39;s factory function to an array of DI tokens plugin wishes to interact with. Karma will pick up this property and pass requested services to the factory functions as parameters.</p>
 <p>Let&#39;s make the <code>hello</code> framework a bit more useful and make it add <code>hello.js</code> file to the <code>files</code> array. This way users of the plugin can, for example, access a function defined in <code>hello.js</code> from their tests.</p>
@@ -190,7 +192,8 @@ helloFrameworkFactory.$inject = [<span class="hljs-string">'config'</span>]
 
 <span class="hljs-built_in">module</span>.exports = {
   <span class="hljs-string">'framework:hello'</span>: [<span class="hljs-string">'factory'</span>, helloFrameworkFactory]
-};</code></pre>
+};
+</code></pre>
 <p>The Karma config is unchanged and is omitted for brevity. See above example for the plugin usage.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Currently, Karma uses <a href="https://github.com/vojtajina/node-di">node-di</a> library as a DI implementation. The library is more powerful than what&#39;s documented above, however, the DI implementation may change in the future, so we recommend not to rely on the node-di implementation details.</div>
 <h2>Plugin types</h2>
@@ -230,7 +233,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 <h3>Reporters</h3>
 <ul>
 <li>example plugins: <a href="https://github.com/karma-runner/karma-growl-reporter">karma-growl-reporter</a>, <a href="https://github.com/karma-runner/karma-junit-reporter">karma-junit-reporter</a>, <a href="https://github.com/ameerthehacker/karma-material-reporter">karma-material-reporter</a></li>

--- a/6.2/dev/public-api.html
+++ b/6.2/dev/public-api.html
@@ -132,22 +132,27 @@ You can, however, call Karma programmatically from your node module. Here is the
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(karmaConfig, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p>Notice the capital &#39;S&#39; on  <code>require(&#39;karma&#39;).Server</code>.</p>
 <h3><strong>server.start()</strong></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><strong>server.refreshFiles()</strong></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3><strong>server.refreshFile(path)</strong></h3>
 <p>Trigger a file refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)</code></pre>
+<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>listening</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -209,13 +214,15 @@ You can, however, call Karma programmatically from your node module. Here is the
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <p><code>runner.run()</code> returns an <code>EventEmitter</code> which emits a <code>progress</code> event passing
 the reporter output as a <code>Buffer</code> object.</p>
 <p>You may listen for that event to print the reporter output to the console:</p>
 <pre><code class="language-javascript">runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}).on(<span class="hljs-string">'progress'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">data</span>) </span>{
   process.stdout.write(data)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.stopper</h2>
 <h3><strong>stopper.stop(options, [callback=process.exit])</strong></h3>
 <p>This function will signal a running server to stop.  The equivalent of <code>karma stop</code>.  </p>
@@ -225,7 +232,8 @@ stopper.stop({<span class="hljs-attr">port</span>: <span class="hljs-number">987
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Server stop as initiated'</span>)
   }
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.config.parseConfig([configFilePath], [cliOptions])</h2>
 <p>This function will load given config file and returns a filled config object.
 This can be useful if you want to integrate karma into another tool and want to load
@@ -234,7 +242,8 @@ uses this to load your karma configuration and use that in the stryker configura
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> cfg = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>).config;
 <span class="hljs-keyword">const</span> path = <span class="hljs-built_in">require</span>(<span class="hljs-string">'path'</span>);
 <span class="hljs-comment">// Read karma.conf.js, but override port with 1337</span>
-<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );</code></pre>
+<span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(path.resolve(<span class="hljs-string">'./karma.conf.js'</span>), { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> } );
+</code></pre>
 <h2>karma.constants</h2>
 <h3><strong>constants.VERSION</strong></h3>
 <p>The current version of karma</p>

--- a/6.2/intro/configuration.html
+++ b/6.2/intro/configuration.html
@@ -161,7 +161,8 @@ Do you want Karma to watch all the files and run the tests on change?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy-paste it from another project ;-)</p>
@@ -169,13 +170,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/6.2/intro/installation.html
+++ b/6.2/intro/installation.html
@@ -142,10 +142,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/6.2/plus/cloud9.html
+++ b/6.2/plus/cloud9.html
@@ -129,11 +129,13 @@ It is written almost entirely in JavaScript and uses NodeJS on the back-end.</p>
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -141,7 +143,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/6.2/plus/codio.html
+++ b/6.2/plus/codio.html
@@ -140,18 +140,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -160,7 +163,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from the right button).</p>
@@ -174,7 +178,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from the right button).</p>

--- a/6.2/plus/emberjs.html
+++ b/6.2/plus/emberjs.html
@@ -128,13 +128,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -165,7 +168,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -185,15 +189,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/6.2/plus/jenkins.html
+++ b/6.2/plus/jenkins.html
@@ -146,7 +146,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -160,7 +161,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/6.2/plus/requirejs.html
+++ b/6.2/plus/requirejs.html
@@ -144,11 +144,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks work just
@@ -187,7 +189,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -210,7 +213,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -268,7 +272,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -295,14 +300,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/6.2/plus/semaphore.html
+++ b/6.2/plus/semaphore.html
@@ -133,26 +133,29 @@ you already have a Semaphore account.</p>
 create one now. This will both document your configuration and
 make it easy to run your tests. Here&#39;s an example:</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.10"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.10&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
-<pre><code class="language-json">"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers Firefox"
-}</code></pre>
+<pre><code class="language-json">&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers Firefox&quot;
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it on a virtual screen
 during your builds.</p>

--- a/6.2/plus/teamcity.html
+++ b/6.2/plus/teamcity.html
@@ -132,14 +132,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during the build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to the build configuration: use Command Line runner and fill in <code>Custom script</code> text area. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> at the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/6.2/plus/travis.html
+++ b/6.2/plus/travis.html
@@ -135,19 +135,21 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root, create one now. Travis runs <code>npm test</code> to trigger your tests, so this
 is where you tell Travis how to run your tests.</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.12"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.12&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite, so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -160,17 +162,20 @@ like this (if you&#39;re using Xenial):</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">dist:</span> xenial
 <span class="hljs-symbol">services:</span>
-  - xvfb</code></pre>
+  - xvfb
+</code></pre>
 <p>Or this, for Trusty and below:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/6.3/about/changelog.html
+++ b/6.3/about/changelog.html
@@ -207,7 +207,8 @@
 </ul>
 <pre><code>const {<span class="hljs-built_in"> Server </span>} = require(<span class="hljs-string">'karma'</span>);
 const<span class="hljs-built_in"> server </span>= new Server();
-server.start();</code></pre>
+server.start();
+</code></pre>
 <ul>
 <li><strong>cli:</strong> Karma is more strict and will error out if unknown option or argument is passed to CLI.</li>
 <li>Using Karma to run Dart code in the browser is no longer supported. Use your favorite Dart-to-JS compiler instead.</li>
@@ -1041,11 +1042,13 @@ to match this new format.</p>
 <ul>
 <li><p>The public api interface has changed to a constructor form. To upgrade change</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> server = <span class="hljs-built_in">require</span>(‘karma’).server
-server.start(config, done)</code></pre>
+server.start(config, done)
+</code></pre>
 <p>to</p>
 <pre><code class="language-javascript"><span class="hljs-keyword">var</span> Server = <span class="hljs-built_in">require</span>(‘karma’).Server
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(config, done)
-server.start()</code></pre>
+server.start()
+</code></pre>
 <p>Closes #1037, #1482, #1467
 (<a href="https://github.com/karma-runner/karma/commit/82cbbadd">82cbbadd</a>)</p>
 </li>
@@ -1675,7 +1678,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
       }
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.3"></a></p>
 <h3>v0.9.3 (2013-06-16)</h3>
 <h4>Bug Fixes</h4>
@@ -1720,7 +1724,8 @@ if you are using <code>karma run</code> with custom <code>--runer-port</code>, p
     <span class="hljs-attr">autoWatch</span>: <span class="hljs-literal">true</span>,
     <span class="hljs-comment">// ...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <p><a name="v0.9.2"></a></p>
 <h3>v0.9.2 (2013-04-16)</h3>
 <h4>Bug Fixes</h4>

--- a/6.3/about/migration.html
+++ b/6.3/about/migration.html
@@ -124,7 +124,8 @@ You can leave all the existing projects using an older version of Karma and only
 version for the new projects. Alternatively, you can migrate the existing projects one at a time...</p>
 <p>Anyway, this migration should be easy ;-) so let&#39;s get started...</p>
 <pre><code class="language-bash"><span class="hljs-built_in">cd</span> &lt;path-to-your-project&gt;
-npm install karma --save-dev</code></pre>
+npm install karma --save-dev
+</code></pre>
 <p>This will install the latest version of Karma and also update <code>package.json</code> of your project.</p>
 <h2>Install missing plugins</h2>
 <p>Karma does not ship with any &quot;default&quot; plugins anymore.
@@ -145,9 +146,11 @@ For new projects, just remember you have to install all the plugins you need. Th
 <p>Karma does not put the <code>karma</code> command in your system PATH anymore.
 If you want to use the <code>karma</code> command, please install the command line interface (<code>karma-cli</code>).</p>
 <p>You probably have the <code>karma</code> package installed globally, in which case you should remove it first:</p>
-<pre><code class="language-bash">npm remove -g karma</code></pre>
+<pre><code class="language-bash">npm remove -g karma
+</code></pre>
 <p>And then install the command line interface:</p>
-<pre><code class="language-bash">npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">npm install -g karma-cli
+</code></pre>
 <h2>Default configuration</h2>
 <p><code>autoWatch</code> is true by default, so if you don&#39;t wanna use it make sure you set it to <code>false</code>.
 But hey, give it a shot first, it&#39;s really awesome to run your tests on every save!</p>

--- a/6.3/about/versioning.html
+++ b/6.3/about/versioning.html
@@ -121,9 +121,11 @@
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Karma uses <a href="http://semver.org">Semantic Versioning</a>.</p>
 <p>It is recommended that you add Karma by running:</p>
-<pre><code class="language-bash">$ yarn add --dev karma</code></pre>
+<pre><code class="language-bash">$ yarn add --dev karma
+</code></pre>
 <p>or: </p>
-<pre><code class="language-bash">$ npm --save-dev install karma</code></pre>
+<pre><code class="language-bash">$ npm --save-dev install karma
+</code></pre>
 
         </div>
       </div>

--- a/6.3/config/browsers.html
+++ b/6.3/config/browsers.html
@@ -120,7 +120,8 @@
       </div>
       <div class="page-columns">
         <div id="markdown" class="sixteen columns bottom"><p>Capturing browsers on your own can be a tedious and time-consuming task. However, Karma can automate this for you. Simply add the browsers you would like to capture into the <a href="configuration-file.html">configuration file</a>.</p>
-<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]</code></pre>
+<pre><code class="language-javascript">browsers: [<span class="hljs-string">'Chrome'</span>]
+</code></pre>
 <p>Then, Karma will take care of auto-capturing these browsers, as well as killing them after the job is over.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the browser launchers need to be loaded as <a href="plugins.html">plugins</a>.</div>
 <h2>Available browser launchers</h2>
@@ -138,13 +139,15 @@
 </ul>
 <p>Here&#39;s an example of how to add Firefox to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install the launcher first with NPM:</span>
-$ npm install karma-firefox-launcher --save-dev</code></pre>
+$ npm install karma-firefox-launcher --save-dev
+</code></pre>
 <p>And then, inside your configuration file, add the browser name in <code>browsers</code> array.</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
     <span class="hljs-attr">browsers</span> : [<span class="hljs-string">'Chrome'</span>, <span class="hljs-string">'Firefox'</span>]
   });
-};</code></pre>
+};
+</code></pre>
 <p>Also, keep in mind that the <code>browsers</code> configuration setting is empty by default.</p>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Capturing any browser manually</h2>
@@ -157,7 +160,8 @@ as the machine running Karma (or using a local tunnel).</p>
 <p>Some of the launchers can also be configured:</p>
 <pre><code class="language-javascript">sauceLabs: {
   <span class="hljs-attr">username</span>: <span class="hljs-string">'michael_jackson'</span>
-}</code></pre>
+}
+</code></pre>
 <p>Or defined as a configured launcher:</p>
 <pre><code class="language-javascript">customLaunchers: {
   <span class="hljs-attr">chrome_without_security</span>: {
@@ -169,7 +173,8 @@ as the machine running Karma (or using a local tunnel).</p>
     <span class="hljs-attr">browserName</span>: <span class="hljs-string">'chrome'</span>,
     <span class="hljs-attr">platform</span>: <span class="hljs-string">'windows'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>A display name can be set for any custom launcher. If set, this name will be used for reporting instead of the
 user agent. Here is a code snippet example explaining how to set a display name for a custom launcher.</p>
 <pre><code class="language-javascript">customLaunchers: {
@@ -178,7 +183,8 @@ user agent. Here is a code snippet example explaining how to set a display name 
     <span class="hljs-attr">flags</span>: [<span class="hljs-string">'--disable-web-security'</span>],
     <span class="hljs-attr">displayName</span>: <span class="hljs-string">'Chrome w/o security'</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>If the definition is as above, the browser will be displayed as <code>Chrome w/o security</code> in logs and reports.</p>
 <h2>Correct path to browser binary</h2>
 <p>Each plugin has some default paths where to find the browser binary on particular OS.
@@ -191,17 +197,21 @@ $ <span class="hljs-built_in">export</span> CHROME_BIN=/usr/<span class="hljs-bu
 $ <span class="hljs-built_in">export</span> CHROME_CANARY_BIN=/usr/<span class="hljs-built_in">local</span>/bin/my-chrome-build
 
 <span class="hljs-comment"># Changing the path to the PhantomJs binary</span>
-$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs</code></pre>
+$ <span class="hljs-built_in">export</span> PHANTOMJS_BIN=<span class="hljs-variable">$HOME</span>/<span class="hljs-built_in">local</span>/bin/phantomjs
+</code></pre>
 <h3>Windows cmd.exe</h3>
-<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe</code></pre>
+<pre><code class="language-bash">C:&gt; SET IE_BIN=C:\Program Files\Internet Explorer\iexplore.exe
+</code></pre>
 <h3>Windows Powershell</h3>
-<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span></code></pre>
+<pre><code class="language-bash"><span class="hljs-variable">$Env</span>:FIREFOX_BIN = <span class="hljs-string">'c:\Program Files (x86)\Mozilla Firefox 4.0 Beta 6\firefox.exe'</span>
+</code></pre>
 <h2>Custom browsers</h2>
 <pre><code class="language-javascript"><span class="hljs-comment">// in the karma.conf.js</span>
 <span class="hljs-attr">browsers</span>: [<span class="hljs-string">'/usr/local/bin/custom-browser.sh'</span>],
 
 <span class="hljs-comment">// from cli</span>
-karma start --browsers /usr/local/bin/custom-browser.sh</code></pre>
+karma start --browsers /usr/local/bin/custom-browser.sh
+</code></pre>
 <p>The browser scripts need to take one argument, which is the URL with the ID-parameter to be used to connect to the server. The supplied ID is used by the server to keep track of which specific browser is captured.</p>
 
         </div>

--- a/6.3/config/configuration-file.html
+++ b/6.3/config/configuration-file.html
@@ -144,13 +144,15 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-coffeescript"><span class="hljs-comment"># karma.conf.coffee</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-params">(config)</span> -&gt;</span>
   config.set
     basePath: <span class="hljs-string">'../..'</span>
     frameworks: [<span class="hljs-string">'jasmine'</span>]
-    <span class="hljs-comment"># ...</span></code></pre>
+    <span class="hljs-comment"># ...</span>
+</code></pre>
 <pre><code class="language-typescript"><span class="hljs-comment">// karma.conf.ts</span>
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
   config.set({
@@ -158,7 +160,8 @@ which accepts one argument: the configuration object.</p>
     frameworks: [<span class="hljs-string">'jasmine'</span>],
     <span class="hljs-comment">//...</span>
   });
-}</code></pre>
+}
+</code></pre>
 <h3>Customized TypeScript Configuration</h3>
 <p>Under the hood Karma uses ts-node to transpile TypeScript to JavaScript. If the resolved <code>tsconfig.json</code> has <code>module</code> configured as <code>ES</code> formats. You might get errors like <code>SyntaxError: Unexpected token</code>. This is due that in Node <code>ES</code> module formats are not supported. To overcome this issue you need to configure ts-node to use <code>commonjs</code> module format.</p>
 <p>Create a JavaScript configuration file that overrides the module format.</p>
@@ -168,7 +171,8 @@ which accepts one argument: the configuration object.</p>
     <span class="hljs-attr">module</span>: <span class="hljs-string">'commonjs'</span>
   }
 });
-<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);</code></pre>
+<span class="hljs-built_in">require</span>(<span class="hljs-string">'./karma.conf.ts'</span>);
+</code></pre>
 <h2>File Patterns</h2>
 <p>All of the configuration options, which specify file paths, use the <a href="https://github.com/isaacs/minimatch">minimatch</a> library to facilitate flexible
 but concise file expressions so you can easily list all of the files you want to include and exclude.</p>
@@ -222,7 +226,8 @@ properties, all of which are optional:</p>
   <span class="hljs-attr">format</span>: string,
   <span class="hljs-attr">path</span>:   string,
   <span class="hljs-attr">terminal</span>: boolean
-}</code></pre>
+}
+</code></pre>
 <p>Here the <code>level</code> is the desired log-level, where level <code>log</code> always is logged. The format
 is a string where <code>%b</code>, <code>%t</code>, <code>%T</code>, and <code>%m</code> are replaced with the browser string,
 log type in lower-case, log type in uppercase, and log message, respectively. This format will
@@ -347,7 +352,8 @@ Custom headers are useful, especially with upcoming browser features like Servic
   <span class="hljs-attr">match</span>: <span class="hljs-string">'.*foo.html'</span>,
   <span class="hljs-attr">name</span>: <span class="hljs-string">'Service-Worker-Allowed'</span>,
   <span class="hljs-attr">value</span>: <span class="hljs-string">'/'</span>
-}]</code></pre>
+}]
+</code></pre>
 <h2>detached</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>false</code></p>
@@ -407,7 +413,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">httpsServerOptions: {
   <span class="hljs-attr">key</span>: fs.readFileSync(<span class="hljs-string">'server.key'</span>, <span class="hljs-string">'utf8'</span>),
   <span class="hljs-attr">cert</span>: fs.readFileSync(<span class="hljs-string">'server.crt'</span>, <span class="hljs-string">'utf8'</span>)
-},</code></pre>
+},
+</code></pre>
 <h2>logLevel</h2>
 <p><strong>Type:</strong> Constant</p>
 <p><strong>Default:</strong> <code>config.LOG_INFO</code></p>
@@ -437,12 +444,14 @@ Use this to prevent accidental disabling tests needed to validate production.</p
     response.writeHead(<span class="hljs-number">200</span>)
     <span class="hljs-keyword">return</span> response.end(<span class="hljs-string">"content!"</span>)
   }
-}</code></pre>
+}
+</code></pre>
 <pre><code class="language-javascript">middleware: [<span class="hljs-string">'custom'</span>]
 <span class="hljs-attr">plugins</span>: [
   {<span class="hljs-string">'middleware:custom'</span>: [<span class="hljs-string">'factory'</span>, CustomMiddlewareFactory]}
   ...
-]</code></pre>
+]
+</code></pre>
 <h2>mime</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>{}</code></p>
@@ -452,7 +461,8 @@ Use this to prevent accidental disabling tests needed to validate production.</p
 <pre><code class="language-javascript">mime: {
    <span class="hljs-string">'text/x-typescript'</span>: [<span class="hljs-string">'ts'</span>,<span class="hljs-string">'tsx'</span>]
    <span class="hljs-string">'text/plain'</span> : [<span class="hljs-string">'mytxt'</span>]
-}</code></pre>
+}
+</code></pre>
 <h2>beforeMiddleware</h2>
 <p><strong>Type:</strong> Array</p>
 <p><strong>Default:</strong> <code>[]</code></p>
@@ -520,7 +530,8 @@ but your interactive debugging does not.</p>
     <span class="hljs-string">'target'</span>: <span class="hljs-string">'http://myserver.localhost'</span>,
     <span class="hljs-string">'changeOrigin'</span>: <span class="hljs-literal">true</span>
   }
-},</code></pre>
+},
+</code></pre>
 <h2>proxyValidateSSL</h2>
 <p><strong>Type:</strong> Boolean</p>
 <p><strong>Default:</strong> <code>true</code></p>
@@ -590,7 +601,8 @@ between browsers and the testing server).</p>
 <p><strong>Example:</strong></p>
 <pre><code class="language-javascript">proxyReq: <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">proxyReq, req, res, options</span>) </span>{
   proxyReq.setHeader(<span class="hljs-string">'Referer'</span>, <span class="hljs-string">'https://www.example.com/'</span>);
-}</code></pre>
+}
+</code></pre>
 <h2>proxyRes</h2>
 <p><strong>Type:</strong> Function</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -603,7 +615,8 @@ between browsers and the testing server).</p>
       <span class="hljs-keyword">return</span> cookie.replace(<span class="hljs-regexp">/\s*secure;?/i</span>, <span class="hljs-string">''</span>);
     })
   }
-}</code></pre>
+}
+</code></pre>
 <h2>upstreamProxy</h2>
 <p><strong>Type:</strong> Object</p>
 <p><strong>Default:</strong> <code>undefined</code></p>
@@ -645,7 +658,8 @@ Trying to start ChromeHeadless again (<span class="hljs-number">1</span>/<span c
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
 Trying to start ChromeHeadless again (<span class="hljs-number">2</span>/<span class="hljs-number">2</span>).
 ChromeHeadless have <span class="hljs-keyword">not</span> captured <span class="hljs-keyword">in</span> <span class="hljs-number">60000</span>ms, killing.
-ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.</code></pre>
+ChromeHeadless failed <span class="hljs-number">2</span> times(timeout). Giving up.
+</code></pre>
 <p>If you see this error, you can try increasing the socket connection timeout.</p>
 
         </div>

--- a/6.3/config/files.html
+++ b/6.3/config/files.html
@@ -221,7 +221,8 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 
   <span class="hljs-comment">// this file will be served on demand from disk and will be ignored by the watcher</span>
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'compiled/app.js.map'</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">true</span>}
-],</code></pre>
+],
+</code></pre>
 <h2>Loading files from another server</h2>
 <p>Pattern can also be an absolute URL. This allows including files which are not served by Karma.</p>
 <p>Example:</p>
@@ -230,7 +231,8 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
     <span class="hljs-string">'https://example.com/my-lib.js'</span>,
     { <span class="hljs-attr">pattern</span>: <span class="hljs-string">'https://example.com/my-lib'</span>, <span class="hljs-attr">type</span>: <span class="hljs-string">'js'</span> }
   ]
-})</code></pre>
+})
+</code></pre>
 <p>Absolute URLs have some special rules comparing to the regular file paths:</p>
 <ul>
 <li>Globing is not support, so each URL must be specified as a separate pattern.</li>
@@ -247,20 +249,23 @@ served - but rather available as <code>window.__html__[&#39;my.html&#39;]</code>
 <p>Example for loading images</p>
 <pre><code class="language-javascript">files: [
   {<span class="hljs-attr">pattern</span>: <span class="hljs-string">'test/images/*.jpg'</span>, <span class="hljs-attr">watched</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">included</span>: <span class="hljs-literal">false</span>, <span class="hljs-attr">served</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">nocache</span>: <span class="hljs-literal">false</span>}
-],</code></pre>
+],
+</code></pre>
 <p>The pattern is a glob which matches the specified image assets. Watched and included are not necessary as images are not tests. However, they will need to be served to the browser.</p>
 <p>In this case an image would be accessed at <code>http://localhost:[PORT]/base/test/images/[MY IMAGE].jpg</code></p>
 <p>Notice the <strong>base</strong> in the URL, it is a reference to your <strong>basePath</strong>. You do not need to replace or provide your own <strong>base</strong>.</p>
 <p>In addition, you can use a proxy</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"http://localhost:8080/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <p>Now you can fetch images in <code>test/images</code> at <code>http://localhost:8080/img/[MY IMAGE].jpg</code></p>
 <p>Change <strong>8080</strong> to the port you use</p>
 <p>You can also use proxies without specifying the protocol, hostname, and port</p>
 <pre><code class="language-javascript">proxies: {
   <span class="hljs-string">"/img/"</span>: <span class="hljs-string">"/base/test/images/"</span>
-},</code></pre>
+},
+</code></pre>
 <h2>Webserver features</h2>
 <ul>
 <li><a href="https://en.wikipedia.org/wiki/Byte_serving">Range requests</a>.</li>

--- a/6.3/config/plugins.html
+++ b/6.3/config/plugins.html
@@ -130,9 +130,11 @@
     <span class="hljs-attr">"karma-growl-reporter"</span>: <span class="hljs-string">"~0.0.1"</span>,
     <span class="hljs-attr">"karma-firefox-launcher"</span>: <span class="hljs-string">"~0.0.1"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Therefore, a simple way to install a plugin is:</p>
-<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-&lt;plugin name&gt; --save-dev
+</code></pre>
 <h2>Loading Plugins</h2>
 <p>By default, Karma loads plugins from all sibling NPM packages which have a name starting with <code>karma-*</code>.</p>
 <p>You can also override this behavior and explicitly list plugins you want to load via the <code>plugins</code> configuration setting:</p>
@@ -152,7 +154,8 @@
     <span class="hljs-string">'karma-chrome-launcher'</span>,
     <span class="hljs-string">'./my-fancy-plugin'</span>
   ]
-})</code></pre>
+})
+</code></pre>
 <h2>Activating Plugins</h2>
 <p>Adding a plugin to the <code>plugins</code> array only makes Karma aware of the plugin, but it does not activate it. Depending on the plugin type you&#39;ll need to add a plugin name into <code>frameworks</code>, <code>reporters</code>, <code>preprocessors</code>, <code>middleware</code> or <code>browsers</code> configuration key to activate it. For the detailed information refer to the corresponding plugin documentation or check out <a href="../dev/plugins.html">Developing plugins</a> guide for more in-depth explanation of how plugins work.</p>
 

--- a/6.3/config/preprocessors.html
+++ b/6.3/config/preprocessors.html
@@ -126,7 +126,8 @@ of the configuration file:</p>
   <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.tea'</span>: [<span class="hljs-string">'coffee'</span>],
   <span class="hljs-string">'**/*.html'</span>: [<span class="hljs-string">'html2js'</span>]
-},</code></pre>
+},
+</code></pre>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>There are multiple expressions referencing the &quot;coffee&quot; preprocessor in this example, as a preprocessor
 can be listed more than once as another way to specify multiple file path expressions.</div>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Most of the preprocessors need to be loaded as <a href="plugins.html">plugins</a>.</div>
@@ -144,7 +145,8 @@ can be listed more than once as another way to specify multiple file path expres
 </ul>
 <p>Here&#39;s an example of how to add the CoffeScript preprocessor to your testing suite:</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Install it first with NPM</span>
-$ npm install karma-coffee-preprocessor --save-dev</code></pre>
+$ npm install karma-coffee-preprocessor --save-dev
+</code></pre>
 <p>And then inside your configuration file...</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -152,7 +154,8 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
       <span class="hljs-string">'**/*.coffee'</span>: [<span class="hljs-string">'coffee'</span>]
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Of course, you can write <a href="../dev/plugins.html">custom plugins</a> too!</p>
 <h2>Configured Preprocessors</h2>
 <p>Some of the preprocessors can also be configured:</p>
@@ -160,14 +163,16 @@ $ npm install karma-coffee-preprocessor --save-dev</code></pre>
   <span class="hljs-attr">options</span>: {
     <span class="hljs-attr">bare</span>: <span class="hljs-literal">false</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p>Or define a configured preprocessor:</p>
 <pre><code class="language-javascript">customPreprocessors: {
   <span class="hljs-attr">bare_coffee</span>: {
     <span class="hljs-attr">base</span>: <span class="hljs-string">'coffee'</span>,
     <span class="hljs-attr">options</span>: {<span class="hljs-attr">bare</span>: <span class="hljs-literal">true</span>}
   }
-}</code></pre>
+}
+</code></pre>
 <h2>Mini matching</h2>
 <p>The keys of the preprocessors config object are used to filter the files specified in
 the <code>files</code> configuration.</p>
@@ -186,7 +191,8 @@ will execute the preprocessors over that file in the order they are listed in
 the corresponding array. So for instance, if the config object is:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then karma will execute <code>&#39;a&#39;</code> before executing <code>&#39;b&#39;</code>.</p>
 <p>If a file matches multiple keys, karma will use the <code>config.preprocessor_priority</code>
 map to set the order. If this config option is not set, karma do its best to
@@ -194,18 +200,21 @@ execute the preprocessors in a reasonable order.  So if you have:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then for <code>a.js</code>, karma will run <code>&#39;a&#39;</code> then <code>&#39;b&#39;</code> then <code>&#39;c&#39;</code>.  If two lists contradict each other, like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'b'</span>, <span class="hljs-string">'a'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>then karma will arbitrarily pick one list to prioritize over the other.  In a
 case like:</p>
 <pre><code class="language-js">preprocessors: {
   <span class="hljs-string">'*.js'</span>: [<span class="hljs-string">'a'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'c'</span>],
   <span class="hljs-string">'a.*'</span>: [<span class="hljs-string">'c'</span>, <span class="hljs-string">'b'</span>, <span class="hljs-string">'d'</span>]
-}</code></pre>
+}
+</code></pre>
 <p>Then <code>&#39;a&#39;</code> will definitely be run first, <code>&#39;d&#39;</code> will definitely be run last, but
 it&#39;s arbitrary if karma will run <code>&#39;b&#39;</code> before <code>&#39;c&#39;</code> or vice versa.</p>
 

--- a/6.3/dev/git-commit-msg.html
+++ b/6.3/dev/git-commit-msg.html
@@ -129,14 +129,16 @@
 
 &lt;body&gt;
 
-&lt;footer&gt;</code></pre>
+&lt;footer&gt;
+</code></pre>
 <h2>Example commit message:</h2>
 <pre><code class="language-bash">fix(middleware): ensure Range headers adhere more closely to RFC 2616
 
 Add one new dependency, use `range-parser` (Express dependency) to compute
 range. It is more well-tested <span class="hljs-keyword">in</span> the wild.
 
-Fixes <span class="hljs-comment">#2310</span></code></pre>
+Fixes <span class="hljs-comment">#2310</span>
+</code></pre>
 <h2>Message subject (first line)</h2>
 <p>The first line cannot be longer than 70 characters, the second line is always blank and
 other lines should be wrapped at 80 characters. The type and scope should
@@ -177,9 +179,11 @@ omitted. In smaller projects such as Karma plugins, the <code>&lt;scope&gt;</cod
 <h2>Message footer</h2>
 <h3>Referencing issues</h3>
 <p>Closed issues should be listed on a separate line in the footer prefixed with &quot;Closes&quot; keyword like this:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#234</span>
+</code></pre>
 <p>or in the case of multiple issues:</p>
-<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span></code></pre>
+<pre><code class="language-bash">Closes <span class="hljs-comment">#123, #245, #992</span>
+</code></pre>
 <h3>Breaking changes</h3>
 <p>All breaking changes have to be mentioned in footer with the
 description of the change, justification and migration notes.</p>
@@ -189,7 +193,8 @@ description of the change, justification and migration notes.</p>
 consistent with the configuration file syntax.
 
 To migrate your project, change all the commands, <span class="hljs-built_in">where</span> you use `--port-runner`
-to `--runner-port`.</code></pre>
+to `--runner-port`.
+</code></pre>
 <hr>
 <p>This document is based on <a href="https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#">AngularJS Git Commit Msg Convention</a>. See the
 <a href="https://github.com/karma-runner/karma/commits/master">commit history</a> for examples of properly-formatted commit messages.</p>

--- a/6.3/dev/making-changes.html
+++ b/6.3/dev/making-changes.html
@@ -136,13 +136,15 @@ Here are some tips on how to set up a Karma workspace and how to send a good pul
 <li>Make sure you have a <a href="https://github.com/signup/free">GitHub account</a>.</li>
 <li><a href="https://github.com/karma-runner/karma/fork">Fork the repository</a> on GitHub.</li>
 <li>Clone your fork<pre><code class="language-bash">$ git <span class="hljs-built_in">clone</span> https://github.com/&lt;your-username&gt;/karma.git
-$ <span class="hljs-built_in">cd</span> karma</code></pre>
+$ <span class="hljs-built_in">cd</span> karma
+</code></pre>
 </li>
 <li>Install for development. Use a recent npm version, ignore peerdep warnings<pre><code class="language-bash">$ npm install
 
 $ npm run init
 <span class="hljs-comment"># or if you're on Windows</span>
-$ npm run init:windows</code></pre>
+$ npm run init:windows
+</code></pre>
 </li>
 </ul>
 <h2>Testing and Building</h2>
@@ -152,17 +154,20 @@ $ npm run init:windows</code></pre>
 <span class="hljs-comment"># or you can run test suits individually</span>
 $ npm run <span class="hljs-built_in">test</span>:unit
 $ npm run <span class="hljs-built_in">test</span>:e2e
-$ npm run <span class="hljs-built_in">test</span>:client</code></pre>
+$ npm run <span class="hljs-built_in">test</span>:client
+</code></pre>
 </li>
 <li><p>Lint the code via:</p>
 <pre><code class="language-bash">$ npm run lint
 <span class="hljs-comment"># or you can also apply auto-fixes where possible</span>
-$ npm run lint:fix</code></pre>
+$ npm run lint:fix
+</code></pre>
 </li>
 <li><p>Build the client code via:</p>
 <pre><code class="language-bash">$ npm run build
 <span class="hljs-comment"># or use the watch mode</span>
-$ npm run build:watch</code></pre>
+$ npm run build:watch
+</code></pre>
 </li>
 </ul>
 <h2>Changing the Code</h2>
@@ -170,7 +175,8 @@ $ npm run build:watch</code></pre>
 <ul>
 <li>Features get the prefix <code>feature-</code>.</li>
 <li>Bug fixes get the prefix <code>fix-</code>.</li>
-<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;</code></pre>
+<li>Improvements to the documentation get the prefix <code>docs-</code>.<pre><code class="language-bash">$ git checkout -b &lt;branch_name&gt;
+</code></pre>
 </li>
 </ul>
 <p>Open your favorite editor, make some changes, run the tests, change the code, run the tests,
@@ -180,9 +186,11 @@ change the code, run the tests, etc.</p>
 </ul>
 <h2>Sending a Pull Request</h2>
 <ul>
-<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span></code></pre>
+<li>Commit your changes (<strong>please follow our <a href="git-commit-msg.html">commit message conventions</a></strong>):<pre><code class="language-bash">$ git commit -m <span class="hljs-string">"..."</span>
+</code></pre>
 </li>
-<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;</code></pre>
+<li>Push to your github repo:<pre><code class="language-bash">$ git push origin &lt;branch_name&gt;
+</code></pre>
 </li>
 <li>Go to the GitHub page and click &quot;Open a Pull request&quot;.</li>
 <li>Write a good description of the change.</li>

--- a/6.3/dev/plugins.html
+++ b/6.3/dev/plugins.html
@@ -153,7 +153,8 @@
   <span class="hljs-comment">// function and use whatever it returns as a service for the DI token</span>
   <span class="hljs-comment">// `framework:hello`.</span>
   <span class="hljs-string">'framework:hello'</span>: [<span class="hljs-string">'factory'</span>, helloFrameworkFactory]
-};</code></pre>
+};
+</code></pre>
 <pre><code class="language-js"><span class="hljs-comment">// karma.conf.js</span>
 
 <span class="hljs-built_in">module</span>.exports = <span class="hljs-function">(<span class="hljs-params">config</span>) =&gt;</span> {
@@ -165,7 +166,8 @@
     <span class="hljs-comment">// corresponding configuration key.</span>
     <span class="hljs-attr">frameworks</span>: [<span class="hljs-string">'hello'</span>]
   })
-}</code></pre>
+}
+</code></pre>
 <h2>Injecting dependencies</h2>
 <p>In &quot;Dependency injection&quot; section we discussed that it is possible to inject any Karma services into a plugin and interact with them. This can be done by setting an <code>$inject</code> property on the plugin&#39;s factory function to an array of DI tokens plugin wishes to interact with. Karma will pick up this property and pass requested services to the factory functions as parameters.</p>
 <p>Let&#39;s make the <code>hello</code> framework a bit more useful and make it add <code>hello.js</code> file to the <code>files</code> array. This way users of the plugin can, for example, access a function defined in <code>hello.js</code> from their tests.</p>
@@ -186,7 +188,8 @@ helloFrameworkFactory.$inject = [<span class="hljs-string">'config'</span>]
 
 <span class="hljs-built_in">module</span>.exports = {
   <span class="hljs-string">'framework:hello'</span>: [<span class="hljs-string">'factory'</span>, helloFrameworkFactory]
-};</code></pre>
+};
+</code></pre>
 <p>The Karma config is unchanged and is omitted for brevity. See above example for the plugin usage.</p>
 <div class="alert alert-success"><h4 class="alert-heading">Note: </h4>Currently, Karma uses <a href="https://github.com/vojtajina/node-di">node-di</a> library as a DI implementation. The library is more powerful than what&#39;s documented above, however, the DI implementation may change in the future, so we recommend not to rely on the node-di implementation details.</div>
 <h2>Plugin types</h2>
@@ -226,7 +229,8 @@ statuses. The method takes an object of the form:</p>
     <span class="hljs-attr">success</span>: <span class="hljs-built_in">Boolean</span>, <span class="hljs-comment">// pass / fail</span>
 
     <span class="hljs-attr">skipped</span>: <span class="hljs-built_in">Boolean</span> <span class="hljs-comment">// skipped / ran</span>
-}</code></pre>
+}
+</code></pre>
 <h3>Reporters</h3>
 <ul>
 <li>example plugins: <a href="https://github.com/karma-runner/karma-growl-reporter">karma-growl-reporter</a>, <a href="https://github.com/karma-runner/karma-junit-reporter">karma-junit-reporter</a>, <a href="https://github.com/ameerthehacker/karma-material-reporter">karma-material-reporter</a></li>

--- a/6.3/dev/public-api.html
+++ b/6.3/dev/public-api.html
@@ -136,7 +136,8 @@ changed in a future major version.</p>
 <span class="hljs-keyword">var</span> server = <span class="hljs-keyword">new</span> Server(karmaConfig, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h5>New Behavior</h5>
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> karma = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>)
 <span class="hljs-keyword">const</span> parseConfig = karma.config.parseConfig
@@ -154,21 +155,26 @@ parseConfig(
     })
   },
   (rejectReason) =&gt; { <span class="hljs-comment">/* respond to the rejection reason error */</span> }
-);</code></pre>
+);
+</code></pre>
 <h3><code>server.start()</code></h3>
 <p>Equivalent of <code>karma start</code>.</p>
-<pre><code class="language-javascript">server.start()</code></pre>
+<pre><code class="language-javascript">server.start()
+</code></pre>
 <h3><code>server.refreshFiles()</code></h3>
 <p>Trigger a file list refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFiles()</code></pre>
+<pre><code class="language-javascript">server.refreshFiles()
+</code></pre>
 <h3><code>server.refreshFile(path)</code></h3>
 <p>Trigger a file refresh. Returns a promise.</p>
-<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)</code></pre>
+<pre><code class="language-javascript">server.refreshFile(<span class="hljs-string">'src/js/module-dep.js'</span>)
+</code></pre>
 <h3>Events</h3>
 <p>The <code>server</code> object is an <a href="https://nodejs.org/docs/latest/api/events.html#events_class_events_eventemitter"><code>EventEmitter</code></a>. You can simply listen to events like this:</p>
 <pre><code class="language-javascript">server.on(<span class="hljs-string">'browser_register'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">browser</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'A new browser was registered'</span>)
-})</code></pre>
+})
+</code></pre>
 <h3><code>listening</code></h3>
 <p><strong>Arguments:</strong></p>
 <ul>
@@ -237,7 +243,8 @@ changed in a future major version.</p>
 runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">exitCode</span>) </span>{
   <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Karma has exited with '</span> + exitCode)
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h5>New Behavior</h5>
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> karma = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>)
 
@@ -253,7 +260,8 @@ karma.config.parseConfig(
     })
   },
   (rejectReason) =&gt; { <span class="hljs-comment">/* respond to the rejection reason error */</span> }
-);</code></pre>
+);
+</code></pre>
 <h4><code>callback</code> argument</h4>
 <p>The callback receives the exit code as the first argument.</p>
 <p>If there is an error, the error code will be provided as the second parameter to
@@ -264,7 +272,8 @@ the reporter output as a <code>Buffer</code> object.</p>
 <p>You may listen for that event to print the reporter output to the console:</p>
 <pre><code class="language-javascript">runner.run({<span class="hljs-attr">port</span>: <span class="hljs-number">9876</span>}).on(<span class="hljs-string">'progress'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">data</span>) </span>{
   process.stdout.write(data)
-})</code></pre>
+})
+</code></pre>
 <h2>karma.stopper</h2>
 <h3><code>stopper.stop(options, [callback=process.exit])</code></h3>
 <p>This function will signal a running server to stop. The equivalent of
@@ -279,7 +288,8 @@ stopper.stop({<span class="hljs-attr">port</span>: <span class="hljs-number">987
     <span class="hljs-built_in">console</span>.log(<span class="hljs-string">'Server stop as initiated'</span>)
   }
   process.exit(exitCode)
-})</code></pre>
+})
+</code></pre>
 <h5>New Behavior</h5>
 <pre><code class="language-javascript"><span class="hljs-keyword">const</span> karma = <span class="hljs-built_in">require</span>(<span class="hljs-string">'karma'</span>)
 
@@ -297,7 +307,8 @@ karma.config.parseConfig(
     })
   },
   (rejectReason) =&gt; { <span class="hljs-comment">/* respond to the rejection reason error */</span> }
-);</code></pre>
+);
+</code></pre>
 <h4><code>callback</code> argument</h4>
 <p>The callback receives the exit code as the first argument.</p>
 <p>If there is an error, the error code will be provided as the second parameter to
@@ -317,7 +328,8 @@ changed in a future major version.</p>
 <span class="hljs-keyword">const</span> karmaConfig = cfg.parseConfig(
   path.resolve(<span class="hljs-string">'./karma.conf.js'</span>),
   { <span class="hljs-attr">port</span>: <span class="hljs-number">1337</span> }
-);</code></pre>
+);
+</code></pre>
 <p>The new behavior in the future will involve throwing exceptions instead of
 exiting the process and aynchronous config files will be supported through the
 use of promises.</p>
@@ -332,7 +344,8 @@ cfg.parseConfig(
 ).then(
   <span class="hljs-function">(<span class="hljs-params">karmaConfig</span>) =&gt;</span> { <span class="hljs-comment">/* use the config with the public API */</span> },
   (rejectReason) =&gt; { <span class="hljs-comment">/* respond to the rejection reason error */</span> }
-);</code></pre>
+);
+</code></pre>
 <h4><code>configFilePath</code> argument</h4>
 <ul>
 <li><strong>Type:</strong> String | <code>null</code> | <code>undefined</code></li>

--- a/6.3/intro/configuration.html
+++ b/6.3/intro/configuration.html
@@ -157,7 +157,8 @@ Do you want Karma to watch all the files and run the tests on change?
 Press tab to list possible options.
 &gt; yes
 
-Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.</code></pre>
+Config file generated at <span class="hljs-string">"/Users/vojta/Code/karma/my.conf.js"</span>.
+</code></pre>
 <p>The configuration file can be written in CoffeeScript as well.
 In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> extension such as <code>karma init karma.conf.coffee</code>, it will generate a CoffeeScript file.</p>
 <p>Of course, you can write the config file by hand or copy-paste it from another project ;-)</p>
@@ -165,13 +166,15 @@ In fact, if you execute <code>karma init</code> with a <code>*.coffee</code> ext
 <p>When starting Karma, the configuration file path can be passed in as the first argument.</p>
 <p>By default, Karma will look for <code>karma.conf.js</code> or <code>karma.conf.coffee</code> in the current directory.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma using your configuration:</span>
-$ karma start my.conf.js</code></pre>
+$ karma start my.conf.js
+</code></pre>
 <p>For more detailed information about the Karma configuration file, such as available options and features,
 please read the <a href="../config/configuration-file.html">configuration file docs</a>.</p>
 <h2>Command line arguments</h2>
 <p>Some configurations, which are already present within the configuration file, can be overridden by specifying the configuration
 as a command line argument for when Karma is executed.</p>
-<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run</code></pre>
+<pre><code class="language-bash">karma start my.conf.js --<span class="hljs-built_in">log</span>-level debug --single-run
+</code></pre>
 <p>Try <code>karma start --help</code> if you want to see all available options.</p>
 <h2>Integrating with Grunt/Gulp</h2>
 <ul>

--- a/6.3/intro/installation.html
+++ b/6.3/intro/installation.html
@@ -138,10 +138,12 @@ working directory and also save these as <code>devDependencies</code> in <code>p
 other developer working on the project will only have to do <code>npm install</code> in order to get all these
 dependencies installed.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Run Karma:</span>
-$ ./node_modules/karma/bin/karma start</code></pre>
+$ ./node_modules/karma/bin/karma start
+</code></pre>
 <h2>Commandline Interface</h2>
 <p>Typing <code>./node_modules/karma/bin/karma start</code> sucks and so you might find it useful to install <code>karma-cli</code> globally. You will need to do this if you want to run Karma on Windows from the command line.</p>
-<pre><code class="language-bash">$ npm install -g karma-cli</code></pre>
+<pre><code class="language-bash">$ npm install -g karma-cli
+</code></pre>
 <p>Then, you can run Karma simply by <code>karma</code> from anywhere and it will always run the local version.</p>
 
         </div>

--- a/6.3/plus/cloud9.html
+++ b/6.3/plus/cloud9.html
@@ -125,11 +125,13 @@ It is written almost entirely in JavaScript and uses NodeJS on the back-end.</p>
 <h2>Configuration</h2>
 <p>First, make sure the <code>karma.conf.js</code> includes the following entries:</p>
 <pre><code class="language-javascript">hostname: process.env.IP,
-<span class="hljs-attr">port</span>: process.env.PORT</code></pre>
+<span class="hljs-attr">port</span>: process.env.PORT
+</code></pre>
 <h2>Capture the browser manually on the local machine</h2>
 <p>You can use any of your local browsers.</p>
 <pre><code class="language-bash"><span class="hljs-comment"># Start Karma without browsers:</span>
-$ karma start --no-browsers</code></pre>
+$ karma start --no-browsers
+</code></pre>
 <p>Now, open <code>http://&lt;projectName&gt;.&lt;cloud9User&gt;.c9.io/</code> in your browser.</p>
 <h2>Run Karma unit tests with PhantomJS</h2>
 <p>It is also possible to run headless PhantomJS on the Cloud9 server.</p>
@@ -137,7 +139,8 @@ $ karma start --no-browsers</code></pre>
 $ npm install karma-phantomjs-launcher
 
 <span class="hljs-comment"># Start Karma:</span>
-$ karma start --browsers PhantomJS</code></pre>
+$ karma start --browsers PhantomJS
+</code></pre>
 
         </div>
       </div>

--- a/6.3/plus/codio.html
+++ b/6.3/plus/codio.html
@@ -136,18 +136,21 @@
   <span class="hljs-attr">"preview"</span>: {
     <span class="hljs-attr">"Karma Preview"</span>: <span class="hljs-string">"http://{{domain}}:8080"</span>
   }
-}</code></pre>
+}
+</code></pre>
 <p><em>If you wish, you can change the port for the <code>Karma Preview</code> entry, but make a note of the change as you will need to include that port in the <code>karma.config js</code> file later.</em></p>
 <h2>Configuration</h2>
 <ul>
 <li>Edit the <code>karma.conf.js</code> and add the following:</li>
 </ul>
 <pre><code>    <span class="hljs-comment">// hostname for the server</span>
-    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,</code></pre>
+    <span class="hljs-attr">hostname</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">'os'</span>).hostname() + <span class="hljs-string">'.codio.io'</span>,
+</code></pre>
 <ul>
 <li><p>Review webserver port entry to ensure same port defined as entered in .codio file</p>
 <pre><code>  <span class="hljs-comment">// web server port</span>
-  port: <span class="hljs-number">8080</span>,</code></pre>
+  port: <span class="hljs-number">8080</span>,
+</code></pre>
 </li>
 </ul>
 <h2>Capture the browser manually on the local machine</h2>
@@ -156,7 +159,8 @@
 <li><p>Either:</p>
 <ul>
 <li><p>Open a Terminal window and enter</p>
-<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers</code></pre>
+<pre><code>  <span class="hljs-symbol">$</span> karma start --<span class="hljs-keyword">no</span>-browsers
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Start</code> from the Run menu (the 2nd from the right button).</p>
@@ -170,7 +174,8 @@
 <li><p>Switch back into your Codio project and either: </p>
 <ul>
 <li><p>Open a new Terminal window and enter</p>
-<pre><code>  $ karma <span class="hljs-keyword">run</span></code></pre>
+<pre><code>  $ karma <span class="hljs-keyword">run</span>
+</code></pre>
 <p>or </p>
 </li>
 <li><p>Select <code>Karma Run</code> from the Run menu (the 2nd from the right button).</p>

--- a/6.3/plus/emberjs.html
+++ b/6.3/plus/emberjs.html
@@ -124,13 +124,16 @@
 <li><p><a href="../intro/installation.html">install karma</a></p>
 </li>
 <li><p>install the qunit plugin</p>
-<pre><code class="language-bash">npm install karma-qunit --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-qunit --save-dev
+</code></pre>
 </li>
 <li><p>install the ember preprocessor plugin</p>
-<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev</code></pre>
+<pre><code class="language-bash">npm install karma-ember-preprocessor --save-dev
+</code></pre>
 </li>
 <li><p>generate a configuration file for karma</p>
-<pre><code class="language-bash">karma init</code></pre>
+<pre><code class="language-bash">karma init
+</code></pre>
 <p>note -the above will walk you through the basic setup. An example configuration file that works with ember.js/qunit and phantomjs is below</p>
 <pre><code class="language-javascript"><span class="hljs-built_in">module</span>.exports = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">config</span>) </span>{
   config.set({
@@ -161,7 +164,8 @@
       <span class="hljs-string">'**/*.handlebars'</span>: <span class="hljs-string">'ember'</span>
     }
   });
-};</code></pre>
+};
+</code></pre>
 <p>Note - the <code>files</code> section above should include all dependencies, ie- jQuery/handlebars/ember.js along with the js and handlebars files required to deploy and run your production ember.js application</p>
 <p>Note - when testing ember applications, it is important that karma does not try to run the tests until the ember application has finished initialization. You will need to include a small bootstrap file in the <code>files</code> section above to enforce this.  Here&#39;s an example:</p>
 <pre><code class="language-javascript">__karma__.loaded = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{};
@@ -181,15 +185,18 @@ App.initializer({
             __karma__.start();
         }
     }
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>add a simple Qunit test</p>
 <pre><code class="language-javascript">test(<span class="hljs-string">'one should equal one'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params"></span>) </span>{
     equal(<span class="hljs-number">1</span>, <span class="hljs-number">1</span>, <span class="hljs-string">'error: one did not equal one'</span>);
-});</code></pre>
+});
+</code></pre>
 </li>
 <li><p>run the tests with karma from the command line</p>
-<pre><code class="language-bash">karma start</code></pre>
+<pre><code class="language-bash">karma start
+</code></pre>
 </li>
 </ol>
 <p>A simple unit / integration tested example app showing karma / qunit / ember in action can be found <a href="https://github.com/toranb/ember-testing-example">here</a></p>

--- a/6.3/plus/jenkins.html
+++ b/6.3/plus/jenkins.html
@@ -142,7 +142,8 @@ on your CI environment.</p>
 <span class="hljs-attr">reporters</span>: [<span class="hljs-string">'dots'</span>, <span class="hljs-string">'junit'</span>],
 <span class="hljs-attr">junitReporter</span>: {
   <span class="hljs-attr">outputFile</span>: <span class="hljs-string">'test-results.xml'</span>
-},</code></pre>
+},
+</code></pre>
 <p>Please note the <code>test-results.xml</code> files will be written to subdirectories
 named after the browsers the tests were run in inside the present working
 directory (and you will need to tell Jenkins where to find them).</p>
@@ -156,7 +157,8 @@ Environment sub-section, check the “Inject environment
 variables to the build process&#39; checkbox. A few textboxes will
 appear and in the “Properties Content” box set the following:</p>
 <pre><code class="language-bash">$ PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/<span class="hljs-built_in">local</span>/bin
-$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span></code></pre>
+$ PHANTOMJS_BIN=/usr/<span class="hljs-built_in">local</span>/bin/phantomjs <span class="hljs-comment">#or wherever PhantomJS happens to be installed</span>
+</code></pre>
 <p>Further down the page, in the Post-build Actions sub-section add a
 <code>Publish JUnit test result report</code> from the Post-build action drop
 down menu. When the textbox labeled Test report XMLs appears, enter

--- a/6.3/plus/requirejs.html
+++ b/6.3/plus/requirejs.html
@@ -140,11 +140,13 @@
     |-- appSpec.js
     `-- <span class="hljs-built_in">test</span>-main.js
 
-3 directories, 9 files</code></pre>
+3 directories, 9 files
+</code></pre>
 <h2>Configure Karma</h2>
 <p>The first step is creating our <code>karma.conf.js</code>. We can do this from the
 command line:</p>
-<pre><code class="language-bash">$ karma init</code></pre>
+<pre><code class="language-bash">$ karma init
+</code></pre>
 <p>This will give you a series of prompts for things such as paths to the source and test
 files as well as which browsers to capture.</p>
 <p>In this example we&#39;ll use Jasmine, but other test frameworks work just
@@ -183,7 +185,8 @@ start the application in our tests.</p>
         <span class="hljs-string">'src/main.js'</span>
     ]
   });
-};</code></pre>
+};
+</code></pre>
 <p>The files property contains every file you want to be available to the
 Karma runner. By default a script tag will be created for the files,
 unless you use the <code>included: false</code> option.</p>
@@ -206,7 +209,8 @@ to load <code>knockout.js</code> before requirejs...</p>
       {pattern: <span class="hljs-symbol">'test</span>/**/*<span class="hljs-type">Spec</span>.js', included: <span class="hljs-literal">false</span>},
 
       <span class="hljs-symbol">'test</span>/test-main.js'
-    ],</code></pre>
+    ],
+</code></pre>
 <h2>Configuring Require.js</h2>
 <p>Just like any Require.js project, you need a main module to bootstrap
 your tests. We do this in <code>test/test-main.js</code>.</p>
@@ -264,7 +268,8 @@ The <code>test/test-main.js</code> file ends up looking like this:</p>
 
   <span class="hljs-comment">// we have to kickoff jasmine, as it is asynchronous</span>
   <span class="hljs-attr">callback</span>: <span class="hljs-built_in">window</span>.__karma__.start
-});</code></pre>
+});
+</code></pre>
 <h2>Using Require.js in tests</h2>
 <p>Tests can now be written as regular Require.js modules. We wrap
 everything in <code>define</code>, and inside we can use the regular test methods,
@@ -291,14 +296,17 @@ such as <code>describe</code> and <code>it</code>. Example:</p>
 
     });
 
-});</code></pre>
+});
+</code></pre>
 <h2>Running the tests</h2>
 <p>We can now run the tests from the command line:</p>
-<pre><code class="language-bash">$ karma start</code></pre>
+<pre><code class="language-bash">$ karma start
+</code></pre>
 <p>If you didn&#39;t configure Karma to watch all the files and run tests
 automatically on any change, you can trigger the tests manually by
 typing:</p>
-<pre><code class="language-bash">$ karma run</code></pre>
+<pre><code class="language-bash">$ karma run
+</code></pre>
 <p><a href="https://github.com/kjbekkelund/karma-requirejs">Here is a running example of Karma with Require.js</a>.</p>
 
         </div>

--- a/6.3/plus/semaphore.html
+++ b/6.3/plus/semaphore.html
@@ -129,26 +129,29 @@ you already have a Semaphore account.</p>
 create one now. This will both document your configuration and
 make it easy to run your tests. Here&#39;s an example:</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.10"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.10&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Another option is to use Firefox as your test browser. To do this, change
 the last part to:</p>
-<pre><code class="language-json">"scripts": {
-   "test": "./node_modules/.bin/karma start --single-run --browsers Firefox"
-}</code></pre>
+<pre><code class="language-json">&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;./node_modules/.bin/karma start --single-run --browsers Firefox&quot;
+}
+</code></pre>
 <p>Now running <code>npm test</code> within your project will run your tests with Karma.</p>
 <h2>Add Your Project to Semaphore</h2>
 <p>Follow the process as shown in the <a href="https://semaphoreci.com/docs/adding-github-bitbucket-project-to-semaphore.html">screencast</a> on the Semaphore docs.</p>
 <p>After the analysis is finished, ignore the Ruby version Semaphore has set
 for you, choose to customize your build commands and use these:</p>
 <pre><code class="language-bash">npm install
-npm <span class="hljs-built_in">test</span></code></pre>
+npm <span class="hljs-built_in">test</span>
+</code></pre>
 <p>That&#39;s it - proceed to your first build. In case you&#39;re using Firefox as
 your test browser, Semaphore will automatically run it on a virtual screen
 during your builds.</p>

--- a/6.3/plus/teamcity.html
+++ b/6.3/plus/teamcity.html
@@ -128,14 +128,16 @@ You may decide to install Karma and Karma-related packages on the agent globally
 Karma installation by different builds.</p>
 <h2>Configure project</h2>
 <p>Add <code>karma-teamcity-reporter</code> as a dependency to your project:</p>
-<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter</code></pre>
+<pre><code>npm i --<span class="hljs-built_in">save</span>-<span class="hljs-built_in">dev</span> karma-teamcity-reporter
+</code></pre>
 <p>It is also a good idea to check that you have all karma npm dependencies listed in your
 <code>package.json</code> file (e.g. <code>karma-jasmine</code>, <code>karma-phantomjs-launcher</code> and so on) to have them
 being installed during the build.</p>
 <h2>Create a new TeamCity build step</h2>
 <p>Add new build step to the build configuration: use Command Line runner and fill in <code>Custom script</code> text area. If you had decided not to install <em>all</em> your NPM dependencies globally
 add <code>npm install</code> at the beginning of the script. Then add command to run Karma, e.g.:</p>
-<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span></code></pre>
+<pre><code>karma start <span class="hljs-params">--reporters</span> teamcity <span class="hljs-params">--single-run</span> <span class="hljs-params">--browsers</span> PhantomJS <span class="hljs-params">--colors</span> <span class="hljs-literal">false</span>
+</code></pre>
 <p>Running Karma with all these options provided via command line allows to run Karma in
 TeamCity build and locally in development environment (with options from configuration
 file).</p>

--- a/6.3/plus/travis.html
+++ b/6.3/plus/travis.html
@@ -131,19 +131,21 @@ already have Travis account.</p>
 following YAML content:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
-  - <span class="hljs-string">"4"</span></code></pre>
+  - <span class="hljs-string">"4"</span>
+</code></pre>
 <h2>Set up a Test Command</h2>
 <p>If you do not already have a <code>package.json</code> in your project root, create one now. Travis runs <code>npm test</code> to trigger your tests, so this
 is where you tell Travis how to run your tests.</p>
 <pre><code class="language-json">// ...snip...
-"devDependencies": {
-  "karma": "~0.12"
+&quot;devDependencies&quot;: {
+  &quot;karma&quot;: &quot;~0.12&quot;
 },
 // ...snip...
-"scripts": {
-   "test": "karma start --single-run --browsers PhantomJS"
+&quot;scripts&quot;: {
+   &quot;test&quot;: &quot;karma start --single-run --browsers PhantomJS&quot;
 }
-// ...snip...</code></pre>
+// ...snip...
+</code></pre>
 <p>Travis will run <code>npm install</code> before every suite, so this is your
 chance to specify any modules your app needs that Travis does not know
 about like Karma.</p>
@@ -156,17 +158,20 @@ like this (if you&#39;re using Xenial):</p>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">dist:</span> xenial
 <span class="hljs-symbol">services:</span>
-  - xvfb</code></pre>
+  - xvfb
+</code></pre>
 <p>Or this, for Trusty and below:</p>
 <pre><code class="language-ruby"><span class="hljs-symbol">language:</span> node_js
 <span class="hljs-symbol">node_js:</span>
   - <span class="hljs-string">"4"</span>
 <span class="hljs-symbol">before_script:</span>
   - export DISPLAY=<span class="hljs-symbol">:</span><span class="hljs-number">99.0</span>
-  - sh -e /etc/init.d/xvfb start</code></pre>
+  - sh -e /etc/init.d/xvfb start
+</code></pre>
 <p>And now, you can run your tests on Firefox, just change the <code>npm test</code>
 command to</p>
-<pre><code class="language-bash">karma start --browsers Firefox --single-run</code></pre>
+<pre><code class="language-bash">karma start --browsers Firefox --single-run
+</code></pre>
 <h2>Notes</h2>
 <ul>
 <li>Travis&#39; Node environment has very little available. If the startup

--- a/tasks/static.js
+++ b/tasks/static.js
@@ -57,29 +57,6 @@ module.exports = function (grunt) {
           } else {
             return `<p>${text}</p>\n`
           }
-        },
-        code (code, infostring, escaped) {
-          const lang = (infostring || '').match(/\S*/)[0]
-          if (this.options.highlight) {
-            const out = this.options.highlight(code, lang).replace(/&#x27;/g, "'").replace(/&quot;/g, '"')
-            // MODIFIED: prevent code which was not changed by highlighter from
-            // being escaped
-            if (out != null) {
-              escaped = true
-              code = out
-            }
-          }
-          if (!lang) {
-            return '<pre><code>' +
-              (escaped ? code : escape(code, true)) +
-              '</code></pre>\n'
-          }
-          return '<pre><code class="' +
-            this.options.langPrefix +
-            escape(lang, true) +
-            '">' +
-            (escaped ? code : escape(code, true)) +
-            '</code></pre>\n'
         }
       },
       tokenizer: {


### PR DESCRIPTION
It was used to reduce diff when changing markdown parser in 0da309a9159bf2315cefd34e0e778f391d9b37cf and is no longer needed. Changes are purely whitespace and escaping of unsafe characters.